### PR TITLE
Fix build: IExecutableNode stubs on BoundExpression + masked VBDeclarationStatement base call

### DIFF
--- a/RDCore.SDK/Model/AST/Abstract/BoundExpression.cs
+++ b/RDCore.SDK/Model/AST/Abstract/BoundExpression.cs
@@ -1,4 +1,5 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System.Collections.Immutable;
 
 namespace RDCore.SDK.Model.AST.Abstract;
 
@@ -7,4 +8,14 @@ namespace RDCore.SDK.Model.AST.Abstract;
 /// </summary>
 /// <param name="SemanticId">A semantic <c>Uri</c> uniquely identifying this specific node.</param>
 /// <param name="Location">The document location (<c>Uri</c>+<c>Range</c>) of the bound expression.</param>
-public abstract record class BoundExpression(Uri SemanticId, Location Location) : BoundNode(SemanticId, Location), IExecutableNode;
+public abstract record class BoundExpression(Uri SemanticId, Location Location) : BoundNode(SemanticId, Location), IExecutableNode
+{
+    /// <summary>
+    /// The <c>string</c> <em>token</em> of the executable node; expressions have no statement token.
+    /// </summary>
+    public string Token => string.Empty;
+    /// <summary>
+    /// The <em>inputs</em> of the executable node; expressions have no inputs.
+    /// </summary>
+    public ImmutableArray<BoundExpression> Inputs => [];
+}

--- a/RDCore.SDK/Model/AST/Expressions/VBAttributeExpression.cs
+++ b/RDCore.SDK/Model/AST/Expressions/VBAttributeExpression.cs
@@ -47,8 +47,8 @@ public record class VBTypedDeclarationExpression(Uri SemanticId, Location Locati
 /// <param name="Modifier">The access modifier token specified, if any.</param>
 /// <param name="IsWithEvents"><c>true</c> if the declaration list includes the <c>WithEvents</c> keyword.</param>
 /// <param name="IsStatic"><c>true</c> if the declaration list includes the <c>Static</c> keyword.</param>
-public record class VBDeclarationStatement(Uri SemanticId, Location Location, VBTypedDeclarationExpression[] Declarations, AccessModifier? Modifier = AccessModifier.Implicit, bool IsWithEvents = false, bool IsStatic = false) 
-    : BoundStatement(SemanticId, Location) { }
+public record class VBDeclarationStatement(Uri SemanticId, Location Location, VBTypedDeclarationExpression[] Declarations, AccessModifier? Modifier = AccessModifier.Implicit, bool IsWithEvents = false, bool IsStatic = false)
+    : BoundStatement(SemanticId, Location, string.Empty, []) { }
 
 
 //public record class VBAssignationStatement(Uri SemanticId, Location Location, SimpleNameExpression TargetExpression, BoundExpression ValueExpression)


### PR DESCRIPTION
Quick build fix as discussed on Teams — main fails with 2× CS0535 since #81.

- `BoundExpression`: the two stubs (`Token` → `string.Empty`, `Inputs` → `[]`) to satisfy `IExecutableNode`.
- `VBDeclarationStatement`: the CS7036 hiding behind those — its base call still passed 2 args to the now-4-arg `BoundStatement`. Stub arguments keep this a pure build fix; if you'd rather have `Token`/`Inputs` as pass-through positional params (like `CallStatement`), happy to change.

Build clean, 0 warnings; 793/793 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)