### PR TITLE
Add minimal CI gating (build + test)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and Test
+
+on:
+ push:
+  branches: [main]
+ pull_request:
+  branches: [main]
+
+permissions:
+ contents: read
+
+jobs:
+ build-and-test:
+  runs-on: ubuntu-latest
+
+  steps:
+   - uses: actions/checkout@v3
+
+   - name: Setup .NET
+     uses: actions/setup-dotnet@v3
+     with:
+      dotnet-version: 10.0
+
+   - name: Build
+     run: dotnet build RDCore.slnx --configuration Release
+
+   - name: Test
+     run: dotnet test RDCore.slnx --configuration Release --no-build --verbosity normal


### PR DESCRIPTION
Closes #85 — the minimal gating from our Teams chat.

One job on ubuntu-latest: `dotnet build RDCore.slnx -c Release` + `dotnet test --no-build`, on PR branches and on pushes to main — the ticket's two checkboxes, nothing else. Style matches `documentation.yml` (same action versions, same indent convention).

Deliberately minimal: no matrix, no coverage gates, no caching — each is its own conversation if ever wanted.

Verified locally at current main (`602b802`): Release build with 0 warnings, 817/817 tests pass — so the first run comes up green.

One switch only you can flip: making the check **required** is branch protection (Settings → Branches); until then it's advisory on PRs.

🤖🧑‍💻 Generated with [Claude Code](https://claude.com/claude-code), driven and reviewed by @imojenisys