### PR TITLE
symbols: ISymbolProvider is a producer, not a sink

### DIFF
--- a/RDCore.SDK/Runtime/Abstract/Execution/ISymbolProvider.cs
+++ b/RDCore.SDK/Runtime/Abstract/Execution/ISymbolProvider.cs
@@ -1,0 +1,25 @@
+﻿using RDCore.SDK.Model.Symbols.Abstract;
+
+namespace RDCore.SDK.Runtime.Abstract.Execution;
+
+/// <summary>
+/// Produces the <see cref="Symbol"/>s a session or semantic context is composed from. Each provider
+/// is constructed with its own source and yields the symbols that source defines.
+/// </summary>
+/// <remarks>
+/// ⚖️ <strong>RDCore</strong> provides implementations of this interface <strong>licensed under GPLv3</strong>:
+/// <list type="bullet">
+/// <item><c>ConfigurationSymbolProvider</c> — precompiler constants from the <c>.rdproj</c> project file, overridden by CLI arguments.</item>
+/// <item><c>ProjectSymbolProvider</c> — the module and reference structure declared by the <c>.rdproj</c>.</item>
+/// <item><c>SyntaxTreeSymbolProvider</c> — declarations resolved from a parsed module's AST (both live and dead precompiler branches).</item>
+/// <item><c>LibrarySymbolProvider</c> — types and members reflected from a referenced library.</item>
+/// </list>
+/// The environment host's own runtime and standard-library symbols are provided the same way.
+/// </remarks>
+public interface ISymbolProvider
+{
+    /// <summary>
+    /// Yields the symbols this provider's source defines. May be lazy.
+    /// </summary>
+    IEnumerable<Symbol> ProvideSymbols();
+}

--- a/RDCore.SDK/Runtime/Abstract/Execution/ISymbolResolver.cs
+++ b/RDCore.SDK/Runtime/Abstract/Execution/ISymbolResolver.cs
@@ -35,17 +35,3 @@ public interface ISymbolResolver
     bool TryRead(MemoryAddress address, [NotNullWhen(true)][MaybeNullWhen(false)] out IBindingHandle? value);
 }
 
-/// <summary>
-/// A service that loads a <see cref="Symbol"/> into the semantic layer.
-/// </summary>
-/// <remarks>
-/// ⚖️<strong>RDCore</strong> provides an implementation of this interface <strong>licensed under GPLv3</strong>.
-/// </remarks>
-public interface ISymbolProvider
-{
-    /// <summary>
-    /// Defines the specified new <see cref="Symbol"/> in the semantic layer (static context), or in the symbol table (runtime context).
-    /// </summary>
-    /// <param name="symbol">The new <see cref="Symbol"/> to be semantically defined.</param>
-    void Define(Symbol symbol);
-}


### PR DESCRIPTION
ISymbolProvider was `{ void Define(Symbol) }` -- a registration endpoint shape, with zero implementations. The planned providers (ConfigurationSymbolProvider, ProjectSymbolProvider, SyntaxTreeSymbolProvider, LibrarySymbolProvider) each *produce* symbols from their own source, so the contract is now
`{ IEnumerable<Symbol> ProvideSymbols() }`, in its own file.

StaticSymbol (its retirement is wanted but it is 88 uses and the base of every operator symbol) is untouched; provider output is ordinary Symbol subtypes. The precompiler-constant symbol type is settled when ConfigurationSymbolProvider is built.