### PR TITLE
runtime: IRuntimeEnvironmentProfile from appsettings.json

### DIFF
--- a/RDCore.SDK/Runtime/Abstract/Execution/IRuntimeEnvironmentProfile.cs
+++ b/RDCore.SDK/Runtime/Abstract/Execution/IRuntimeEnvironmentProfile.cs
@@ -1,0 +1,42 @@
+﻿using System.Globalization;
+
+namespace RDCore.SDK.Runtime.Abstract.Execution;
+
+/// <summary>
+/// An immutable description of the host environment an execution session runs in — the facts VBA
+/// semantics depend on that are neither in the source nor derivable from it.
+/// </summary>
+/// <remarks>
+/// Supplied by the environment host (from <c>appsettings.json</c>, overridable by the host). Design-
+/// time and tests use <see cref="RuntimeEnvironmentProfile.Default"/>.
+/// </remarks>
+public interface IRuntimeEnvironmentProfile
+{
+    /// <summary>
+    /// <c>true</c> for a 64-bit environment. Determines <c>LongPtr</c> width and the value of the
+    /// <c>#If Win64</c> / <c>#If VBA7</c> pre-compiler directives.
+    /// </summary>
+    bool Is64Bit { get; }
+
+    /// <summary>
+    /// The environment locale identifier (LCID). <c>0</c> means the invariant locale.
+    /// </summary>
+    int Lcid { get; }
+
+    /// <summary>
+    /// The <see cref="CultureInfo"/> for <see cref="Lcid"/> — drives <c>Option Compare Text</c>,
+    /// <c>Like</c>, <c>Format$</c>, and number / date let-coercion to and from <c>String</c>.
+    /// </summary>
+    CultureInfo Culture { get; }
+
+    /// <summary>
+    /// The ANSI code page for <c>Byte()</c> ↔ <c>String</c> conversions and the non-Unicode behaviour
+    /// of <c>Chr</c> / <c>Asc</c>.
+    /// </summary>
+    int AnsiCodePage { get; }
+
+    /// <summary>
+    /// <c>true</c> when the host supports the <c>Option Compare Database</c> directive (Microsoft Access).
+    /// </summary>
+    bool SupportsOptionCompareDatabase { get; }
+}

--- a/RDCore.SDK/Runtime/RuntimeEnvironmentProfile.cs
+++ b/RDCore.SDK/Runtime/RuntimeEnvironmentProfile.cs
@@ -1,0 +1,35 @@
+﻿using RDCore.SDK.Runtime.Abstract.Execution;
+using System.Globalization;
+
+namespace RDCore.SDK.Runtime;
+
+/// <summary>
+/// The default <see cref="IRuntimeEnvironmentProfile"/> implementation.
+/// </summary>
+/// <param name="Is64Bit">Whether the environment is 64-bit.</param>
+/// <param name="Lcid">The environment LCID; <c>0</c> for the invariant locale.</param>
+/// <param name="AnsiCodePage">The ANSI code page for <c>Byte()</c> ↔ <c>String</c>.</param>
+/// <param name="SupportsOptionCompareDatabase">Whether <c>Option Compare Database</c> is supported.</param>
+public sealed record class RuntimeEnvironmentProfile(
+    bool Is64Bit,
+    int Lcid,
+    int AnsiCodePage,
+    bool SupportsOptionCompareDatabase) : IRuntimeEnvironmentProfile
+{
+    /// <summary>
+    /// A 64-bit, current-culture, Windows-1252, no-<c>Option Compare Database</c> profile for
+    /// design-time and tests.
+    /// </summary>
+    public static IRuntimeEnvironmentProfile Default { get; } = new RuntimeEnvironmentProfile(
+        Is64Bit: true,
+        Lcid: 0,
+        AnsiCodePage: 1252,
+        SupportsOptionCompareDatabase: false);
+
+    /// <summary>Builds a profile from bound <c>appsettings.json</c> options.</summary>
+    public static RuntimeEnvironmentProfile From(Server.Configuration.SdkEnvironmentOptions options)
+        => new(options.Is64Bit, options.Lcid, options.AnsiCodePage, options.SupportsOptionCompareDatabase);
+
+    /// <inheritdoc/>
+    public CultureInfo Culture => Lcid == 0 ? CultureInfo.InvariantCulture : CultureInfo.GetCultureInfo(Lcid);
+}

--- a/RDCore.SDK/Server/AppHost.cs
+++ b/RDCore.SDK/Server/AppHost.cs
@@ -2,11 +2,14 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using RDCore.SDK.Client;
 using RDCore.SDK.Client.Connection;
 using RDCore.SDK.Extensibility;
 using RDCore.SDK.Platform;
+using RDCore.SDK.Runtime;
+using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Server.Configuration;
 using RDCore.SDK.Server.Services;
 using RDCore.SDK.Server.Services.States;
@@ -191,6 +194,8 @@ public abstract class AppHost<TApp>() : IDisposable
         services.Configure<SdkServerOptions>(config.GetSection("Server"));
 
         services
+            .AddSingleton<IRuntimeEnvironmentProfile>(sp =>
+                RuntimeEnvironmentProfile.From(sp.GetRequiredService<IOptions<SdkAppOptions>>().Value.Environment))
             .AddSingleton<TApp>()
             .AddTransient<IServerStateProvider, ServerStateProvider>()
             .AddTransient<IRDCoreServerProcess, RDCoreServerProcess>()

--- a/RDCore.SDK/Server/Configuration/SdkServerOptions.cs
+++ b/RDCore.SDK/Server/Configuration/SdkServerOptions.cs
@@ -139,6 +139,34 @@ public record class SdkAppOptions
     /// Platform options.
     /// </summary>
     public SdkPlatformOptions Platform { get; set; } = new();
+    /// <summary>
+    /// Runtime environment profile options — the host facts VBA semantics depend on.
+    /// </summary>
+    public SdkEnvironmentOptions Environment { get; set; } = new();
+}
+
+/// <summary>
+/// Runtime environment settings, bound from <c>appsettings.json</c>. These become the session's
+/// <c>IRuntimeEnvironmentProfile</c>.
+/// </summary>
+public record class SdkEnvironmentOptions
+{
+    /// <summary>
+    /// <c>true</c> for a 64-bit environment (<c>LongPtr</c> width, <c>#If Win64</c> / <c>#If VBA7</c>).
+    /// </summary>
+    public bool Is64Bit { get; set; } = true;
+    /// <summary>
+    /// The environment locale identifier. <c>0</c> (the default) means the invariant locale.
+    /// </summary>
+    public int Lcid { get; set; }
+    /// <summary>
+    /// The ANSI code page for <c>Byte()</c> ↔ <c>String</c> and non-Unicode <c>Chr</c> / <c>Asc</c>.
+    /// </summary>
+    public int AnsiCodePage { get; set; } = 1252;
+    /// <summary>
+    /// <c>true</c> when the host supports the <c>Option Compare Database</c> directive (Microsoft Access).
+    /// </summary>
+    public bool SupportsOptionCompareDatabase { get; set; }
 }
 
 public record class SdkServerAppOptions

--- a/RDCore.Tests/Runtime/RuntimeEnvironmentProfileTests.cs
+++ b/RDCore.Tests/Runtime/RuntimeEnvironmentProfileTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.Configuration;
+using RDCore.SDK.Runtime;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Server.Configuration;
+using System.Globalization;
+
+namespace RDCore.Tests.Runtime;
+
+[TestClass]
+public sealed class RuntimeEnvironmentProfileTests
+{
+    [TestMethod]
+    public void Default_Is64BitInvariantWindows1252NoDatabase()
+    {
+        var sut = RuntimeEnvironmentProfile.Default;
+
+        Assert.IsTrue(sut.Is64Bit);
+        Assert.AreEqual(0, sut.Lcid);
+        Assert.AreEqual(1252, sut.AnsiCodePage);
+        Assert.IsFalse(sut.SupportsOptionCompareDatabase);
+        Assert.AreEqual(CultureInfo.InvariantCulture, sut.Culture);
+    }
+
+    [TestMethod]
+    public void From_MapsEveryOption()
+    {
+        var options = new SdkEnvironmentOptions
+        {
+            Is64Bit = false,
+            Lcid = 1036, // fr-FR
+            AnsiCodePage = 1250,
+            SupportsOptionCompareDatabase = true,
+        };
+
+        IRuntimeEnvironmentProfile sut = RuntimeEnvironmentProfile.From(options);
+
+        Assert.IsFalse(sut.Is64Bit);
+        Assert.AreEqual(1036, sut.Lcid);
+        Assert.AreEqual(1250, sut.AnsiCodePage);
+        Assert.IsTrue(sut.SupportsOptionCompareDatabase);
+        Assert.AreEqual("fr-FR", sut.Culture.Name);
+    }
+
+    [TestMethod]
+    public void BindsFromAppSettingsConfigurationSection()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Configuration:Environment:Is64Bit"] = "false",
+                ["Configuration:Environment:Lcid"] = "1033",
+                ["Configuration:Environment:AnsiCodePage"] = "932",
+                ["Configuration:Environment:SupportsOptionCompareDatabase"] = "true",
+            })
+            .Build();
+
+        var options = configuration.GetSection("Configuration").Get<SdkAppOptions>()!.Environment;
+        var sut = RuntimeEnvironmentProfile.From(options);
+
+        Assert.IsFalse(sut.Is64Bit);
+        Assert.AreEqual(1033, sut.Lcid);
+        Assert.AreEqual(932, sut.AnsiCodePage);
+        Assert.IsTrue(sut.SupportsOptionCompareDatabase);
+    }
+
+    [TestMethod]
+    public void MissingSection_YieldsTheDefaults()
+    {
+        var options = new ConfigurationBuilder().Build()
+            .GetSection("Configuration").Get<SdkAppOptions>() ?? new SdkAppOptions();
+
+        Assert.IsTrue(options.Environment.Is64Bit);
+        Assert.AreEqual(1252, options.Environment.AnsiCodePage);
+    }
+}


### PR DESCRIPTION
The host facts VBA semantics depend on -- bitness (LongPtr / #If Win64 / #If VBA7), locale/LCID (Option Compare Text, Like, Format$, string let-coercion), ANSI code page (Byte()<->String, Chr/Asc), and Option Compare Database support -- now have a home: IRuntimeEnvironmentProfile (SDK), with an immutable RuntimeEnvironmentProfile record, a Default for design-time/tests, and a SdkEnvironmentOptions config DTO bound from the appsettings.json "Configuration:Environment" section. AppHost registers it as a singleton.

Not yet wired into IRuntimeSession or consumed by Like / string let-coercion -- those follow once a session composition root exists. 1032 -> 1036 tests.