### PR TITLE
symbols: ConfigurationSymbolProvider for project #Const constants

### DIFF
--- a/RDCore.Runtime/Symbols/ConfigurationSymbolProvider.cs
+++ b/RDCore.Runtime/Symbols/ConfigurationSymbolProvider.cs
@@ -1,0 +1,57 @@
+﻿using RDCore.SDK.Model.Symbols;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Values;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Runtime.Symbols;
+
+/// <summary>
+/// Produces the project-level conditional-compilation constants a session starts with: the built-in
+/// host constants derived from the <see cref="IRuntimeEnvironmentProfile"/>, the <c>.rdproj</c>
+/// <c>#Const</c>s, and (highest precedence) <c>--define</c> command-line overrides.
+/// </summary>
+/// <remarks>
+/// ⚖️ GPLv3. Values that are not a recognised literal are skipped.
+/// </remarks>
+public sealed class ConfigurationSymbolProvider(
+    IRuntimeEnvironmentProfile environment,
+    RDCoreProject project,
+    IReadOnlyDictionary<string, string>? overrides = null) : ISymbolProvider
+{
+    private static readonly IReadOnlyDictionary<string, string> _noOverrides = new Dictionary<string, string>();
+
+    public IEnumerable<Symbol> ProvideSymbols()
+    {
+        var defined = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // highest precedence first; the HashSet makes the first definition of a name win.
+        foreach (var (name, source) in ByPrecedence())
+        {
+            if (defined.Add(name) && PrecompilerConstantExpression.TryParse(source, out var value))
+            {
+                yield return new PrecompilerConstantSymbol(name, value);
+            }
+        }
+    }
+
+    private IEnumerable<(string Name, string Source)> ByPrecedence()
+    {
+        foreach (var entry in overrides ?? _noOverrides)
+        {
+            yield return (entry.Key, entry.Value);
+        }
+
+        foreach (var entry in project.PrecompilerConstants)
+        {
+            yield return (entry.Key, entry.Value);
+        }
+
+        yield return ("Win16", "0");
+        yield return ("Win32", environment.Is64Bit ? "0" : "-1");
+        yield return ("Win64", environment.Is64Bit ? "-1" : "0");
+        yield return ("Mac", "0");
+        yield return ("VBA6", "0");
+        yield return ("VBA7", "-1");
+    }
+}

--- a/RDCore.SDK/Model/Symbols/PrecompilerConstantSymbol.cs
+++ b/RDCore.SDK/Model/Symbols/PrecompilerConstantSymbol.cs
@@ -1,0 +1,19 @@
+﻿using RDCore.SDK.Model.Source;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Values.Abstract;
+
+namespace RDCore.SDK.Model.Symbols;
+
+/// <summary>
+/// A project-level conditional-compilation constant (<strong>MS-VBAL §3.4.1</strong>) — supplied by
+/// the <c>.rdproj</c> or a <c>--define</c> argument, and shadowed by a module's own <c>#Const</c>.
+/// </summary>
+/// <remarks>
+/// The declared type of the binding is <c>Variant</c>; <see cref="Value"/> is the concrete data value
+/// of the constant expression.
+/// </remarks>
+/// <param name="Name">The constant's name.</param>
+/// <param name="Value">The constant's data value.</param>
+public sealed record class PrecompilerConstantSymbol(string Name, VBTypedValue Value)
+    : UnboundTypedSymbol(StaticSymbol.GlobalUri, StaticSymbol.GlobalUri, Name, ScopeKind.Unallocated, SymbolKindExt.Constant, VBVariantType.TypeInfo);

--- a/RDCore.SDK/Model/Values/PrecompilerConstantExpression.cs
+++ b/RDCore.SDK/Model/Values/PrecompilerConstantExpression.cs
@@ -1,0 +1,77 @@
+﻿using RDCore.SDK.Model.Values.Abstract;
+using RDCore.SDK.Model.Values.Intrinsic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace RDCore.SDK.Model.Values;
+
+/// <summary>
+/// Parses the literal source text of a project-level <c>#Const</c> value (from the <c>.rdproj</c> or a
+/// <c>--define</c> argument) into a <see cref="VBTypedValue"/>, following the literal-typing rules of
+/// <strong>MS-VBAL §3.3.2</strong>.
+/// </summary>
+/// <remarks>
+/// 👉 Only bare literals (optionally with a leading <c>-</c>) are recognised — the full
+/// <c>&lt;cc-expression&gt;</c> operator grammar is a semantic-layer concern. An unrecognised value is
+/// rejected rather than guessed.
+/// </remarks>
+public static class PrecompilerConstantExpression
+{
+    public static bool TryParse(string? source, [NotNullWhen(true)] out VBTypedValue? value)
+    {
+        value = null;
+        var text = source?.Trim();
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        if (text.Equals("True", StringComparison.OrdinalIgnoreCase)) { value = new VBBooleanValue(true); return true; }
+        if (text.Equals("False", StringComparison.OrdinalIgnoreCase)) { value = new VBBooleanValue(false); return true; }
+        if (text.Equals("Empty", StringComparison.OrdinalIgnoreCase)) { value = VBEmptyValue.Empty; return true; }
+        if (text.Equals("Null", StringComparison.OrdinalIgnoreCase)) { value = VBNullValue.Null; return true; }
+        if (text.Equals("Nothing", StringComparison.OrdinalIgnoreCase)) { value = VBObjectValue.Nothing; return true; }
+
+        if (text.Length >= 2 && text[0] == '"' && text[^1] == '"')
+        {
+            value = new VBStringValue(text[1..^1].Replace("\"\"", "\""));
+            return true;
+        }
+
+        if (text.Length >= 2 && text[0] == '#' && text[^1] == '#'
+            && DateTime.TryParse(text[1..^1], CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+        {
+            value = new VBDateValue(date.ToOADate());
+            return true;
+        }
+
+        var numeric = text;
+        var negative = numeric.StartsWith('-');
+        if (negative || numeric.StartsWith('+'))
+        {
+            numeric = numeric[1..].TrimStart();
+        }
+
+        if (!numeric.Contains('.') && !numeric.Contains('E', StringComparison.OrdinalIgnoreCase)
+            && long.TryParse(numeric, NumberStyles.None, CultureInfo.InvariantCulture, out var integral))
+        {
+            if (negative) { integral = -integral; }
+            // MS-VBAL 3.3.2: an unsuffixed integer literal is the smallest of Integer, Long, Double.
+            value = integral switch
+            {
+                >= short.MinValue and <= short.MaxValue => new VBIntegerValue((short)integral),
+                >= int.MinValue and <= int.MaxValue => new VBLongValue((int)integral),
+                _ => new VBDoubleValue(integral),
+            };
+            return true;
+        }
+
+        if (double.TryParse(numeric, NumberStyles.Float, CultureInfo.InvariantCulture, out var real))
+        {
+            value = new VBDoubleValue(negative ? -real : real);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/RDCore.Tests/Model/Values/PrecompilerConstantExpressionTests.cs
+++ b/RDCore.Tests/Model/Values/PrecompilerConstantExpressionTests.cs
@@ -1,0 +1,54 @@
+﻿using RDCore.SDK.Model.Values;
+using RDCore.SDK.Model.Values.Intrinsic;
+
+namespace RDCore.Tests.Model.Values;
+
+[TestClass]
+[TestCategory("MS-VBAL 3.4.1 Conditional Compilation Const Directive")]
+public sealed class PrecompilerConstantExpressionTests
+{
+    [TestMethod]
+    [DataRow("1", typeof(VBIntegerValue))]
+    [DataRow("-1", typeof(VBIntegerValue))]
+    [DataRow("40000", typeof(VBLongValue))]
+    [DataRow("3.5", typeof(VBDoubleValue))]
+    [DataRow("\"debug\"", typeof(VBStringValue))]
+    [DataRow("True", typeof(VBBooleanValue))]
+    [DataRow("false", typeof(VBBooleanValue))]
+    [DataRow("Empty", typeof(VBEmptyValue))]
+    [DataRow("Null", typeof(VBNullValue))]
+    public void TryParse_TypesLiteralsPerMsVbal332(string source, Type expected)
+    {
+        Assert.IsTrue(PrecompilerConstantExpression.TryParse(source, out var value), source);
+        Assert.IsInstanceOfType(value, expected);
+    }
+
+    [TestMethod]
+    public void TryParse_Integer_HasValue()
+    {
+        Assert.IsTrue(PrecompilerConstantExpression.TryParse("-1", out var value));
+        Assert.AreEqual((short)-1, ((VBIntegerValue)value!).Value);
+    }
+
+    [TestMethod]
+    public void TryParse_String_UnescapesDoubledQuotes()
+    {
+        Assert.IsTrue(PrecompilerConstantExpression.TryParse("\"a\"\"b\"", out var value));
+        Assert.AreEqual("a\"b", ((VBStringValue)value!).Value);
+    }
+
+    [TestMethod]
+    public void TryParse_Date_IsOaSerial()
+    {
+        Assert.IsTrue(PrecompilerConstantExpression.TryParse("#2024-01-15#", out var value));
+        Assert.AreEqual(new DateTime(2024, 1, 15).ToOADate(), ((VBDateValue)value!).SerialValue);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
+    [DataRow("SomeOtherConst")]
+    [DataRow("1 + 2")]
+    public void TryParse_RejectsNonLiterals(string? source)
+        => Assert.IsFalse(PrecompilerConstantExpression.TryParse(source, out _));
+}

--- a/RDCore.Tests/Runtime/ConfigurationSymbolProviderTests.cs
+++ b/RDCore.Tests/Runtime/ConfigurationSymbolProviderTests.cs
@@ -1,0 +1,82 @@
+﻿using RDCore.Runtime.Symbols;
+using RDCore.SDK.Model.Symbols;
+using RDCore.SDK.Model.Values.Intrinsic;
+using RDCore.SDK.Runtime;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Tests.Runtime;
+
+[TestClass]
+[TestCategory("MS-VBAL 3.4.1 Conditional Compilation Const Directive")]
+public sealed class ConfigurationSymbolProviderTests
+{
+    private static IRuntimeEnvironmentProfile Env(bool is64) => new RuntimeEnvironmentProfile(is64, 0, 1252, false);
+
+    private static Dictionary<string, PrecompilerConstantSymbol> Provide(
+        IRuntimeEnvironmentProfile env, RDCoreProject project, IReadOnlyDictionary<string, string>? overrides = null)
+        => new ConfigurationSymbolProvider(env, project, overrides)
+            .ProvideSymbols()
+            .Cast<PrecompilerConstantSymbol>()
+            .ToDictionary(s => s.Name, s => s, StringComparer.OrdinalIgnoreCase);
+
+    [TestMethod]
+    public void BuiltIns_ReflectBitness()
+    {
+        var x64 = Provide(Env(true), new RDCoreProject());
+        Assert.AreEqual((short)-1, ((VBIntegerValue)x64["Win64"].Value).Value);
+        Assert.AreEqual((short)0, ((VBIntegerValue)x64["Win32"].Value).Value);
+        Assert.AreEqual((short)-1, ((VBIntegerValue)x64["VBA7"].Value).Value);
+
+        var x86 = Provide(Env(false), new RDCoreProject());
+        Assert.AreEqual((short)0, ((VBIntegerValue)x86["Win64"].Value).Value);
+        Assert.AreEqual((short)-1, ((VBIntegerValue)x86["Win32"].Value).Value);
+    }
+
+    [TestMethod]
+    public void RdprojConstants_AreProvided_AndShadowBuiltIns()
+    {
+        var project = new RDCoreProject
+        {
+            PrecompilerConstants = { ["RDDEBUG"] = "1", ["MODE"] = "\"debug\"", ["Win64"] = "0" },
+        };
+
+        var symbols = Provide(Env(true), project);
+
+        Assert.AreEqual((short)1, ((VBIntegerValue)symbols["RDDEBUG"].Value).Value);
+        Assert.AreEqual("debug", ((VBStringValue)symbols["MODE"].Value).Value);
+        Assert.AreEqual((short)0, ((VBIntegerValue)symbols["Win64"].Value).Value, "the .rdproj entry shadows the built-in");
+    }
+
+    [TestMethod]
+    public void CliOverrides_ShadowRdprojAndBuiltIns()
+    {
+        var project = new RDCoreProject { PrecompilerConstants = { ["RDDEBUG"] = "0" } };
+        var overrides = new Dictionary<string, string> { ["RDDEBUG"] = "1", ["VBA7"] = "0" };
+
+        var symbols = Provide(Env(true), project, overrides);
+
+        Assert.AreEqual((short)1, ((VBIntegerValue)symbols["RDDEBUG"].Value).Value);
+        Assert.AreEqual((short)0, ((VBIntegerValue)symbols["VBA7"].Value).Value);
+    }
+
+    [TestMethod]
+    public void UnparsableConstant_IsSkipped()
+    {
+        var project = new RDCoreProject { PrecompilerConstants = { ["BAD"] = "1 + 1", ["GOOD"] = "1" } };
+
+        var symbols = Provide(Env(true), project);
+
+        Assert.IsFalse(symbols.ContainsKey("BAD"));
+        Assert.IsTrue(symbols.ContainsKey("GOOD"));
+    }
+
+    [TestMethod]
+    public void EveryConstant_IsVariantDeclared()
+    {
+        foreach (var symbol in Provide(Env(true), new RDCoreProject { PrecompilerConstants = { ["X"] = "1" } }).Values)
+        {
+            Assert.AreEqual("Variant", symbol.ResolvedType.Name);
+        }
+    }
+}


### PR DESCRIPTION
The first ISymbolProvider implementation. Yields the project-level conditional-compilation constants (MS-VBAL 3.4.1) a session starts with:

- built-in host constants from IRuntimeEnvironmentProfile.Is64Bit (Win16/Win32/Win64/Mac/VBA6/VBA7)
- .rdproj RDCoreProject.PrecompilerConstants
- an optional overrides map (CLI --define; the arg wiring is a follow-up)

with first-wins precedence overrides > .rdproj > built-ins, names case-insensitive.

New PrecompilerConstantSymbol (Variant-declared per 3.4.1, carries the data value) and PrecompilerConstantExpression.TryParse (bare literal cc-expression -> VBTypedValue per 3.3.2 literal typing; non-literals rejected).

1036 -> 1059 tests.