### PR TITLE
runtime: compose a session from symbol providers + a --define CLI arg

### DIFF
--- a/RDCore.Runtime/Execution/RuntimeSession.cs
+++ b/RDCore.Runtime/Execution/RuntimeSession.cs
@@ -9,9 +9,13 @@ using System.Runtime.CompilerServices;
 
 namespace RDCore.Runtime.Execution;
 
-internal sealed class RuntimeSession(ISessionMemoryAllocator memory, ISessionSymbols symbols, ISessionObjects objects) : IRuntimeSession
+internal sealed class RuntimeSession(
+    IRuntimeEnvironmentProfile environment,
+    ISessionMemoryAllocator memory,
+    ISessionSymbols symbols,
+    ISessionObjects objects) : IRuntimeSession
 {
-    public bool Is64Bit { get; init; }
+    public IRuntimeEnvironmentProfile Environment { get; init; } = environment;
     public ISessionMemoryAllocator Memory { get; init; } = memory;
     public ISessionSymbols Symbols { get; init; } = symbols;
     public ISessionObjects Objects { get; init; } = objects;
@@ -133,7 +137,10 @@ internal sealed class SessionSymbols : ISessionSymbols
             ?? FindCandidates(name, _workspaceSymbols).OfType<AccessibleTypedSymbol>()
                 .SingleOrDefault(s => IsAccessibleFrom(s, scope))
             ?? FindCandidates(name, _globalSymbols).OfType<AccessibleTypedSymbol>()
-                .FirstOrDefault(s => IsAccessibleFrom(s, scope));
+                .FirstOrDefault(s => IsAccessibleFrom(s, scope))
+            // precompiler constants, intrinsic globals, module symbols — not AccessibleTypedSymbol
+            ?? FindCandidates(name, _globalSymbols).FirstOrDefault()
+            ?? FindCandidates(name, _workspaceSymbols).FirstOrDefault();
         return symbol != default;
     }
 

--- a/RDCore.Runtime/Execution/RuntimeSessionComposer.cs
+++ b/RDCore.Runtime/Execution/RuntimeSessionComposer.cs
@@ -1,0 +1,36 @@
+﻿using RDCore.Runtime.Execution.Memory;
+using RDCore.SDK.Runtime.Abstract.Execution;
+
+namespace RDCore.Runtime.Execution;
+
+/// <summary>
+/// Builds an <see cref="IRuntimeSession"/> from a host environment profile and a set of symbol
+/// providers, running each provider and defining its symbols into the session's symbol table.
+/// </summary>
+public static class RuntimeSessionComposer
+{
+    /// <inheritdoc cref="Compose(IRuntimeEnvironmentProfile, IEnumerable{ISymbolProvider})"/>
+    public static IRuntimeSession Compose(IRuntimeEnvironmentProfile environment, params ISymbolProvider[] providers)
+        => Compose(environment, (IEnumerable<ISymbolProvider>)providers);
+
+    /// <summary>
+    /// Composes a session. Providers are applied in order — an earlier provider's symbol wins a name
+    /// collision (<see cref="ISessionSymbols.TryDefine"/> keeps the first).
+    /// </summary>
+    public static IRuntimeSession Compose(IRuntimeEnvironmentProfile environment, IEnumerable<ISymbolProvider> providers)
+    {
+        var memory = new SessionMemory(new FreeListManager(), environment.Is64Bit ? PointerSize.x64 : PointerSize.x86);
+        var symbols = new SessionSymbols();
+        var objects = new SessionObjects();
+
+        foreach (var provider in providers)
+        {
+            foreach (var symbol in provider.ProvideSymbols())
+            {
+                symbols.TryDefine(symbol, symbol.ScopeKind);
+            }
+        }
+
+        return new RuntimeSession(environment, memory, symbols, objects);
+    }
+}

--- a/RDCore.Runtime/Symbols/ProjectSymbolProvider.cs
+++ b/RDCore.Runtime/Symbols/ProjectSymbolProvider.cs
@@ -1,0 +1,31 @@
+﻿using RDCore.SDK.Model.Symbols;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Runtime.Symbols;
+
+/// <summary>
+/// Produces the module symbols declared by a <c>.rdproj</c>'s <see cref="RDCoreProject"/> — one per
+/// source module, without parsing it.
+/// </summary>
+/// <remarks>
+/// ⚖️ GPLv3. Library reference symbols are the <c>LibrarySymbolProvider</c>'s responsibility; member
+/// symbols are the <c>SyntaxTreeSymbolProvider</c>'s.
+/// </remarks>
+public sealed class ProjectSymbolProvider(Uri workspaceRoot, RDCoreProject project) : ISymbolProvider
+{
+    public IEnumerable<Symbol> ProvideSymbols()
+    {
+        foreach (var module in project.Modules)
+        {
+            var name = module.DefaultName;
+            var isClass = module.Super is not null
+                || string.Equals(Path.GetExtension(module.RelativeUri), ".cls", StringComparison.OrdinalIgnoreCase);
+
+            yield return isClass
+                ? new VBClassModuleSymbol(workspaceRoot, workspaceRoot, name)
+                : new VBStandardModuleSymbol(workspaceRoot, workspaceRoot, name);
+        }
+    }
+}

--- a/RDCore.SDK/Model/Symbols/PrecompilerConstantSymbol.cs
+++ b/RDCore.SDK/Model/Symbols/PrecompilerConstantSymbol.cs
@@ -16,4 +16,4 @@ namespace RDCore.SDK.Model.Symbols;
 /// <param name="Name">The constant's name.</param>
 /// <param name="Value">The constant's data value.</param>
 public sealed record class PrecompilerConstantSymbol(string Name, VBTypedValue Value)
-    : UnboundTypedSymbol(StaticSymbol.GlobalUri, StaticSymbol.GlobalUri, Name, ScopeKind.Unallocated, SymbolKindExt.Constant, VBVariantType.TypeInfo);
+    : UnboundTypedSymbol(StaticSymbol.GlobalUri, StaticSymbol.GlobalUri, Name, ScopeKind.Global, SymbolKindExt.Constant, VBVariantType.TypeInfo);

--- a/RDCore.SDK/Runtime/Abstract/Execution/IRuntimeSession.cs
+++ b/RDCore.SDK/Runtime/Abstract/Execution/IRuntimeSession.cs
@@ -16,10 +16,15 @@ namespace RDCore.SDK.Runtime.Abstract.Execution;
 public interface IRuntimeSession
 {
     /// <summary>
+    /// The host environment this session runs in (bitness, locale, code page, …).
+    /// </summary>
+    IRuntimeEnvironmentProfile Environment { get; }
+
+    /// <summary>
     /// <c>true</c> when the session describes a 64-bit environment. Determines <c>LongPtr</c> width
     /// and the value of <c>#If Win64</c> / <c>#If VBA7</c> pre-compiler directives.
     /// </summary>
-    bool Is64Bit { get; }
+    bool Is64Bit => Environment.Is64Bit;
 
     /// <summary>
     /// The session's memory allocator — tracks allocation size and fragmentation, MSVBVM-style.

--- a/RDCore.SDK/Runtime/Abstract/Execution/IRuntimeSession.cs
+++ b/RDCore.SDK/Runtime/Abstract/Execution/IRuntimeSession.cs
@@ -16,15 +16,10 @@ namespace RDCore.SDK.Runtime.Abstract.Execution;
 public interface IRuntimeSession
 {
     /// <summary>
-    /// The host environment this session runs in (bitness, locale, code page, …).
+    /// The host environment this session runs in — bitness (<c>Environment.Is64Bit</c> drives
+    /// <c>LongPtr</c> width and <c>#If Win64</c> / <c>#If VBA7</c>), locale, code page, …
     /// </summary>
     IRuntimeEnvironmentProfile Environment { get; }
-
-    /// <summary>
-    /// <c>true</c> when the session describes a 64-bit environment. Determines <c>LongPtr</c> width
-    /// and the value of <c>#If Win64</c> / <c>#If VBA7</c> pre-compiler directives.
-    /// </summary>
-    bool Is64Bit => Environment.Is64Bit;
 
     /// <summary>
     /// The session's memory allocator — tracks allocation size and fragmentation, MSVBVM-style.

--- a/RDCore.SDK/Server/Configuration/SdkServerOptions.cs
+++ b/RDCore.SDK/Server/Configuration/SdkServerOptions.cs
@@ -91,6 +91,32 @@ public record class SdkAppCommandLineArgs
     public string? WorkspaceUri { get; set; }
 
     /// <summary>
+    /// Repeatable <em>command-line argument</em> defining or overriding a project-level precompiler
+    /// constant, in <c>NAME=VALUE</c> form (e.g. <c>--define RDDEBUG=1</c>). Overrides the
+    /// <c>.rdproj</c> and the built-in host constants.
+    /// </summary>
+    [Option('D', "define")]
+    public IEnumerable<string>? Define { get; set; }
+
+    /// <summary>
+    /// The <c>--define</c> arguments parsed into a <c>NAME → VALUE</c> map (case-insensitive; the last
+    /// value wins). Malformed entries are ignored.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> PrecompilerConstantOverrides()
+    {
+        var overrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in Define ?? [])
+        {
+            var separator = entry.IndexOf('=');
+            if (separator > 0)
+            {
+                overrides[entry[..separator].Trim()] = entry[(separator + 1)..].Trim();
+            }
+        }
+        return overrides;
+    }
+
+    /// <summary>
     /// Projects the supplied arguments onto <c>IConfiguration</c> keys.
     /// </summary>
     /// <remarks>

--- a/RDCore.Tests/Runtime/RuntimeSessionComposerTests.cs
+++ b/RDCore.Tests/Runtime/RuntimeSessionComposerTests.cs
@@ -26,12 +26,7 @@ public sealed class RuntimeSessionComposerTests
 
     [TestMethod]
     public void ComposedSession_CarriesTheEnvironment()
-    {
-        var session = Compose(is64Bit: true, new RDCoreProject());
-
-        Assert.IsTrue(session.Environment.Is64Bit);
-        Assert.IsTrue(session.Is64Bit); // default interface member off Environment
-    }
+        => Assert.IsTrue(Compose(is64Bit: true, new RDCoreProject()).Environment.Is64Bit);
 
     [TestMethod]
     public void ConfigurationSymbols_ResolveInTheSession()

--- a/RDCore.Tests/Runtime/RuntimeSessionComposerTests.cs
+++ b/RDCore.Tests/Runtime/RuntimeSessionComposerTests.cs
@@ -1,0 +1,75 @@
+﻿using RDCore.Runtime.Execution;
+using RDCore.Runtime.Symbols;
+using RDCore.SDK.Model.Symbols;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Values.Intrinsic;
+using RDCore.SDK.Runtime;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Tests.Runtime;
+
+[TestClass]
+public sealed class RuntimeSessionComposerTests
+{
+    private static readonly Uri WorkspaceRoot = new("file:///c:/ws/");
+    private static readonly Symbol GlobalScope = GlobalSymbols.UnresolvedSymbol;
+
+    private static IRuntimeSession Compose(bool is64Bit, RDCoreProject project, IReadOnlyDictionary<string, string>? defines = null)
+    {
+        var environment = new RuntimeEnvironmentProfile(is64Bit, 0, 1252, false);
+        return RuntimeSessionComposer.Compose(
+            environment,
+            new ConfigurationSymbolProvider(environment, project, defines),
+            new ProjectSymbolProvider(WorkspaceRoot, project));
+    }
+
+    [TestMethod]
+    public void ComposedSession_CarriesTheEnvironment()
+    {
+        var session = Compose(is64Bit: true, new RDCoreProject());
+
+        Assert.IsTrue(session.Environment.Is64Bit);
+        Assert.IsTrue(session.Is64Bit); // default interface member off Environment
+    }
+
+    [TestMethod]
+    public void ConfigurationSymbols_ResolveInTheSession()
+    {
+        var project = new RDCoreProject { PrecompilerConstants = { ["RDDEBUG"] = "1" } };
+
+        var session = Compose(is64Bit: true, project);
+
+        Assert.IsTrue(session.Symbols.TryResolve("Win64", GlobalScope, out var win64));
+        Assert.AreEqual((short)-1, ((VBIntegerValue)((PrecompilerConstantSymbol)win64!).Value).Value);
+
+        Assert.IsTrue(session.Symbols.TryResolve("RDDEBUG", GlobalScope, out var rdDebug));
+        Assert.AreEqual((short)1, ((VBIntegerValue)((PrecompilerConstantSymbol)rdDebug!).Value).Value);
+    }
+
+    [TestMethod]
+    public void CliDefine_OverridesInTheComposedSession()
+    {
+        var project = new RDCoreProject { PrecompilerConstants = { ["RDDEBUG"] = "0" } };
+        var defines = new Dictionary<string, string> { ["RDDEBUG"] = "1" };
+
+        var session = Compose(is64Bit: true, project, defines);
+
+        Assert.IsTrue(session.Symbols.TryResolve("RDDEBUG", GlobalScope, out var rdDebug));
+        Assert.AreEqual((short)1, ((VBIntegerValue)((PrecompilerConstantSymbol)rdDebug!).Value).Value);
+    }
+
+    [TestMethod]
+    public void ProjectModuleSymbols_ResolveInTheSession()
+    {
+        var project = new RDCoreProject
+        {
+            Modules = [new RDCoreModule { RelativeUri = "src/MyModule.bas" }],
+        };
+
+        var session = Compose(is64Bit: true, project);
+
+        Assert.IsTrue(session.Symbols.TryResolve("MyModule", GlobalScope, out var module));
+        Assert.IsInstanceOfType<VBStandardModuleSymbol>(module);
+    }
+}


### PR DESCRIPTION
RuntimeSessionComposer.Compose(IRuntimeEnvironmentProfile, providers) builds an IRuntimeSession, running each ISymbolProvider and defining its symbols into the session table.

- IRuntimeSession gains Environment (the IRuntimeEnvironmentProfile); Is64Bit is now a default interface member reading it. RuntimeSession ctor takes the profile.
- ProjectSymbolProvider yields a module symbol per .rdproj source module (standard vs class from extension / Super); references and members are other providers' jobs.
- --define NAME=VALUE (repeatable) on SdkAppCommandLineArgs + PrecompilerConstantOverrides() -> ConfigurationSymbolProvider's overrides.
- PrecompilerConstantSymbol scope Unallocated -> Global so the session table stores it; SessionSymbols.TryResolve falls back to name lookup for global/module symbols that aren't AccessibleTypedSymbol.

SyntaxTreeSymbolProvider (AST declaration nodes -> symbols, with dead #If branch retention) is the next PR -- it's greenfield.