### PR TITLE
parser: a Declare/Event no longer poisons later declaration capture

### DIFF
--- a/RDCore.Parsing/AST/DeclarationsParseTreeListener.cs
+++ b/RDCore.Parsing/AST/DeclarationsParseTreeListener.cs
@@ -388,7 +388,11 @@ internal class DeclarationsParseTreeListener(Uri sourceUri, ModuleNode moduleNod
     {
         _parameterIndex = 0;
         _isAfterArgsList = true;
-        _isInsideProcedure = true;
+        // NOTE: do NOT set _isInsideProcedure here. It is already set by OnEnterProcedure for a real
+        // Sub/Function/Property body; a Declare or Event has an argList but no body, and setting it
+        // here left the flag poisoned (declaration-pass expression capture off) for every module-level
+        // declaration between a Declare/Event and the next procedure. This whole flag disappears once
+        // the listener also builds statement nodes (TokenSemanticsListener).
 
         if (_isPropertyWriterMember)
         {

--- a/RDCore.Tests/Parser/DeclarationPassParserTests.cs
+++ b/RDCore.Tests/Parser/DeclarationPassParserTests.cs
@@ -2,6 +2,8 @@ using RDCore.Parsing;
 using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.AST.Declarations;
 using RDCore.SDK.Model.AST.Directives;
+using RDCore.SDK.Model.AST.Expressions;
+using RDCore.SDK.Model.Values.Intrinsic;
 using System.Text.Json;
 
 namespace RDCore.Tests.Parser;
@@ -173,6 +175,39 @@ End Sub
         else
         {
             Assert.Inconclusive(result.SyntaxErrors[0]!.Description);
+        }
+    }
+
+    [TestMethod]
+    public void DeclareOrEvent_DoesNotPoisonLaterModuleDeclarationCapture()
+    {
+        // regression: a Declare/Event has an argList but no body, and ExitArgList used to set
+        // _isInsideProcedure, leaving declaration-pass expression capture off for every module-level
+        // declaration between it and the next procedure.
+        const string content = """
+            Option Explicit
+            Declare PtrSafe Sub Foo Lib "k" (ByVal a As Long)
+            Public Const Answer As Long = 42
+            """;
+
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
+
+        var literal = Descendants(result.SyntaxTree!).OfType<LiteralExpressionNode>().SingleOrDefault();
+        Assert.IsNotNull(literal, "the Const's '42' literal was dropped from the AST");
+        Assert.IsInstanceOfType<VBIntegerValue>(literal!.StaticValue);
+        Assert.AreEqual((short)42, ((VBIntegerValue)literal.StaticValue).Value);
+    }
+
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        foreach (var child in node.Children)
+        {
+            yield return child;
+            foreach (var descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
         }
     }
 }


### PR DESCRIPTION
ExitArgList unconditionally set _isInsideProcedure, but a Declare or Event statement has an argList and no body, so after one the declaration-pass expression gate stayed off for every module-level declaration up to the next procedure -- e.g. `Declare ...` followed by `Public Const Answer As Long = 42` dropped the `42` literal from the AST.

_isInsideProcedure is already set by OnEnterProcedure for real bodies, so ExitArgList doesn't need to touch it. The whole flag goes away once the listener also builds statement nodes.

Adds a regression test. 1063 -> 1064.