### PR TITLE
lsp: workspace load + parser round-trip + ast symbol provider

### DIFF
--- a/RDCore.LanguageServer/CoreLanguageServerApp.cs
+++ b/RDCore.LanguageServer/CoreLanguageServerApp.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Options;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using RDCore.LanguageServer.Parsing;
+using RDCore.LanguageServer.Workspace.Services;
 using RDCore.SDK.Client;
 using RDCore.SDK.Extensibility;
 using RDCore.SDK.Platform;
@@ -28,6 +30,8 @@ internal sealed class CoreLanguageServerApp(
     IExtensionsProvider extensionsProvider,
     IHealthCheckService<CoreLanguageServerApp> healthCheckService,
     ILanguageServerProtocolTransportLayer transportLayer,
+    IWorkspaceService workspace,
+    IParsingClientService parsing,
     ILogger<CoreLanguageServerApp> logger)
     : RDCoreServerApp(options, serverStateProvider, healthCheckService, transportLayer, logger)
 {
@@ -139,10 +143,34 @@ internal sealed class CoreLanguageServerApp(
         };
     }
 
-    protected override Task OnLanguageServerInitializeAsync(ILanguageServer server, InitializeParams request, CancellationToken cancellationToken)
+    protected override async Task OnLanguageServerInitializeAsync(ILanguageServer server, InitializeParams request, CancellationToken cancellationToken)
     {
-        LogIfEnabled(LogLevel.Information, "Received LSP/Initialize request.");
-        return base.OnLanguageServerInitializeAsync(server, request, cancellationToken);
+        await LoadWorkspaceAsync(request);
+        await base.OnLanguageServerInitializeAsync(server, request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Loads the project file and its documents. Runs here because the server is still
+    /// <c>Initializing</c> — the window <see cref="IWorkspaceService.LoadAsync"/> requires. A load
+    /// failure is logged, not fatal: the server still completes the LSP handshake.
+    /// </summary>
+    private async Task LoadWorkspaceAsync(InitializeParams request)
+    {
+        if (request.RootUri is null)
+        {
+            LogIfEnabled(LogLevel.Warning, "No RootUri in the initialize request; workspace will not be loaded.");
+            return;
+        }
+
+        try
+        {
+            await workspace.LoadAsync(request.RootUri.GetFileSystemPath());
+            LogIfEnabled(LogLevel.Information, "✅ Workspace loaded");
+        }
+        catch (Exception exception)
+        {
+            LogIfEnabled(LogLevel.Error, $"❌ Workspace could not be loaded:\n{exception}");
+        }
     }
 
     protected async override Task OnLanguageServerInitializedAsync(ILanguageServer server, InitializeParams request, InitializeResult response, CancellationToken cancellationToken)
@@ -161,7 +189,8 @@ internal sealed class CoreLanguageServerApp(
         _coreComponentBringUps.Add(BringUpCoreComponentAsync("parsing server", orchestration.ParsingService, _componentsCts.Token));
         _coreComponentBringUps.Add(BringUpCoreComponentAsync("environment host", orchestration.RuntimeEnvironment, _componentsCts.Token));
 
-        // TODO some ParsingClientService should be responsible for caching ASTs.
+        // once the parsing server is ready, parse every loaded workspace document and cache the ASTs.
+        _coreComponentBringUps.Add(parsing.ParseWorkspaceAsync(_componentsCts.Token));
     }
 
     /// <summary>

--- a/RDCore.LanguageServer/CoreLanguageServerHost.cs
+++ b/RDCore.LanguageServer/CoreLanguageServerHost.cs
@@ -1,8 +1,13 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using RDCore.LanguageServer.Parsing;
+using RDCore.LanguageServer.Server;
+using RDCore.LanguageServer.Workspace.Services;
+using RDCore.LanguageServer.Workspace.States;
 using RDCore.SDK.Platform;
 using System.IO;
+using System.IO.Abstractions;
 using RDCore.SDK.Server;
 using RDCore.SDK.Server.Services;
 
@@ -20,6 +25,21 @@ internal sealed class CoreLanguageServerHost() : RDCorePlatformServerHost<CoreLa
             .AddSingleton<IRDCoreServerProxyFactory, RDCoreServerProxyFactory>()
             .AddSingleton<IPlatformCompositionService, PlatformCompositionService>()
             .AddSingleton<IPlatformOrchestrationService, PlatformOrchestrationService>();
+
+        // workspace loader: the project file, its documents, and their load-state machine.
+        // IFileSystem is already registered by AppHost; the workspace services take the split
+        // abstractions, so project them here.
+        services
+            .AddSingleton(Info.Version ?? new Version(0, 0, 0))
+            .AddSingleton(ProtocolSupportedLanguage.VBA)
+            .AddSingleton<IPath>(sp => sp.GetRequiredService<IFileSystem>().Path)
+            .AddSingleton<IFile>(sp => sp.GetRequiredService<IFileSystem>().File)
+            .AddSingleton<IDirectory>(sp => sp.GetRequiredService<IFileSystem>().Directory)
+            .AddSingleton<IProjectFileService, ProjectFileService>()
+            .AddSingleton<IDocumentStateProvider, DocumentStateProvider>()
+            .AddSingleton<IWorkspaceDocumentService, WorkspaceDocumentService>()
+            .AddSingleton<IWorkspaceService, WorkspaceService>()
+            .AddSingleton<IParsingClientService, ParsingClientService>();
     }
 
     protected override void ConfigureExternalLogging(IServiceCollection services, ILoggingBuilder builder, IConfiguration configuration)

--- a/RDCore.LanguageServer/Parsing/ParsingClientService.cs
+++ b/RDCore.LanguageServer/Parsing/ParsingClientService.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using RDCore.LanguageServer.Workspace;
+using RDCore.LanguageServer.Workspace.Services;
+using RDCore.SDK.Model.AST;
+using RDCore.SDK.Model.AST.Declarations;
+using RDCore.SDK.Platform.Protocol;
+
+namespace RDCore.LanguageServer.Parsing;
+
+/// <summary>
+/// Sends <c>rdcore/parser/document</c> requests to the parsing server and caches the returned
+/// <see cref="ModuleParseResult"/> per document. This is the language server's only entry point to
+/// the parser transport.
+/// </summary>
+internal interface IParsingClientService
+{
+    /// <summary>
+    /// Parses one workspace document, waiting for the parsing server to be ready first, and caches the result.
+    /// </summary>
+    Task<ModuleParseResult> ParseDocumentAsync(Uri documentUri, ModuleType moduleType, CancellationToken token);
+
+    /// <summary>
+    /// Parses every currently-loaded workspace source document. Failures are logged, not thrown.
+    /// </summary>
+    Task ParseWorkspaceAsync(CancellationToken token);
+
+    /// <summary>
+    /// Gets the last <see cref="ModuleParseResult"/> cached for <paramref name="documentUri"/>.
+    /// </summary>
+    bool TryGetCached(Uri documentUri, out ModuleParseResult result);
+}
+
+internal sealed class ParsingClientService(
+    IPlatformOrchestrationService orchestration,
+    IWorkspaceDocumentService documents,
+    ILogger<ParsingClientService> logger) : IParsingClientService
+{
+    private static readonly HashSet<string> _classModuleExtensions =
+        new(StringComparer.OrdinalIgnoreCase) { ".cls", ".frm", ".doccls" };
+
+    private readonly ConcurrentDictionary<Uri, ModuleParseResult> _cache = new();
+
+    public bool TryGetCached(Uri documentUri, out ModuleParseResult result)
+        => _cache.TryGetValue(documentUri, out result!);
+
+    public async Task<ModuleParseResult> ParseDocumentAsync(Uri documentUri, ModuleType moduleType, CancellationToken token)
+    {
+        await orchestration.ParsingService.WaitForReadyAsync(token);
+
+        var result = await orchestration.ParsingService.SendRequestAsync<ParseDocumentParams, ModuleParseResult>(
+            new ParseDocumentParams { DocumentUri = documentUri, ModuleType = moduleType }, token);
+
+        _cache[documentUri] = result;
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogInformation("📄 Parsed {uri}: {status}", documentUri,
+                result.IsSuccess ? "ok" : $"{result.SyntaxErrors.Length} syntax error(s)");
+        }
+        return result;
+    }
+
+    public async Task ParseWorkspaceAsync(CancellationToken token)
+    {
+        try
+        {
+            await orchestration.ParsingService.WaitForReadyAsync(token);
+
+            foreach (var document in documents.GetAllDocuments())
+            {
+                token.ThrowIfCancellationRequested();
+                await ParseDocumentAsync(document.Id.Uri.ToUri(), ModuleTypeOf(document), token);
+            }
+
+            LogIfEnabled(LogLevel.Information, "✅ Workspace parse completed");
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            LogIfEnabled(LogLevel.Information, "Workspace parse was cancelled; language server is shutting down.");
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "❌ Workspace parse failed.");
+        }
+    }
+
+    private static ModuleType ModuleTypeOf(WorkspaceDocument document)
+        => _classModuleExtensions.Contains(document.Extension) ? ModuleType.ClassModule : ModuleType.StdModule;
+
+    private void LogIfEnabled(LogLevel level, string message)
+    {
+        if (logger.IsEnabled(level))
+        {
+            logger.Log(level, "{message}", message);
+        }
+    }
+}

--- a/RDCore.LanguageServer/Program.cs
+++ b/RDCore.LanguageServer/Program.cs
@@ -2,6 +2,7 @@
 using RDCore.SDK.Server;
 
 [assembly: InternalsVisibleTo("RDCore.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 namespace RDCore.LanguageServer;
 
 public class Program

--- a/RDCore.LanguageServer/Symbols/SymbolBuilder.cs
+++ b/RDCore.LanguageServer/Symbols/SymbolBuilder.cs
@@ -1,0 +1,219 @@
+using RDCore.SDK.Model;
+using RDCore.SDK.Model.AST.Abstract;
+using RDCore.SDK.Model.AST.Declarations;
+using RDCore.SDK.Model.AST.Expressions;
+using RDCore.SDK.Model.Source;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Symbols.VBProject;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Abstract;
+using RDCore.SDK.Model.Types.Complex;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using System.Collections.Immutable;
+
+namespace RDCore.LanguageServer.Symbols;
+
+/// <summary>
+/// Turns a declaration AST node into the bound <see cref="Symbol"/> it declares. One trivial method
+/// per node kind, mirroring <c>DeclarationNodeBuilder</c> on the parsing side. Declared types are
+/// resolved through <see cref="ISymbolResolver"/> so the same call path binds real types once a
+/// resolver with intrinsic/library/project symbols is available; a type reference that doesn't
+/// resolve stays <see cref="VBUnknownType"/>.
+/// </summary>
+internal sealed class SymbolBuilder(Uri workspaceRoot, Uri moduleUri, ISymbolResolver resolver)
+{
+    // MS-VBAL 3.3.2 type-declaration characters name a reserved type the resolver can bind.
+    private static readonly ImmutableDictionary<string, string> _typeHintNames = new Dictionary<string, string>
+    {
+        ["%"] = VBTypeNames.VBInteger,
+        ["&"] = VBTypeNames.VBLong,
+        ["^"] = VBTypeNames.VBLongLong,
+        ["!"] = VBTypeNames.VBSingle,
+        ["#"] = VBTypeNames.VBDouble,
+        ["@"] = VBTypeNames.VBCurrency,
+        ["$"] = VBTypeNames.VBString,
+    }.ToImmutableDictionary();
+
+    public Symbol BuildProcedure(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        var symbol = new VBProcedureMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, SymbolKindExt.Procedure,
+            VBVoidType.TypeInfo, range, range, node.AccessModifier);
+        return symbol with { Parameters = BuildParameters(node, symbol.Uri) };
+    }
+
+    public Symbol BuildFunction(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        var symbol = new VBFunctionMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, SymbolKindExt.Function,
+            VBUnknownType.TypeInfo, range, range, node.AccessModifier);
+        return symbol with
+        {
+            ResolvedType = ReturnType(node, symbol.Uri),
+            Parameters = BuildParameters(node, symbol.Uri),
+        };
+    }
+
+    public Symbol BuildPropertyGet(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        var symbol = new VBPropertyGetMemberSymbol(
+            workspaceRoot, moduleUri, ScopeKind.Instance, node.Name, range, range, node.AccessModifier);
+        return symbol with { Parameters = BuildParameters(node, symbol.Uri) };
+    }
+
+    public Symbol BuildPropertyLet(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        var symbol = new VBPropertyLetMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, SymbolKindExt.Property,
+            VBVoidType.TypeInfo, range, range, node.AccessModifier);
+        return symbol with { Parameters = BuildParameters(node, symbol.Uri) };
+    }
+
+    public Symbol BuildPropertySet(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        var symbol = new VBPropertySetMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, SymbolKindExt.Property,
+            VBVoidType.TypeInfo, range, range, node.AccessModifier);
+        return symbol with { Parameters = BuildParameters(node, symbol.Uri) };
+    }
+
+    public Symbol BuildExternal(ExternalMemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        if (node.MemberKind == MemberKind.ExternalFunction)
+        {
+            var function = new VBExternalFunctionMemberSymbol(
+                workspaceRoot, moduleUri, node.Name, ScopeKind.External, SymbolKindExt.Function,
+                VBUnknownType.TypeInfo, range, range, node.AccessModifier, node.IsPtrSafe, node.Library, node.Alias);
+            return function with
+            {
+                ResolvedType = ReturnType(node, function.Uri),
+                Parameters = BuildParameters(node, function.Uri),
+            };
+        }
+
+        var procedure = new VBExternalSubMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.External, SymbolKindExt.Procedure,
+            VBVoidType.TypeInfo, range, range, node.AccessModifier, node.IsPtrSafe, node.Library, node.Alias);
+        return procedure with { Parameters = BuildParameters(node, procedure.Uri) };
+    }
+
+    public Symbol BuildEvent(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        return new VBEventMemberSymbol(workspaceRoot, moduleUri, node.Name, range, range, node.AccessModifier);
+    }
+
+    public Symbol BuildUserDefinedType(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        return new VBUserDefinedTypeMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, range, range, node.AccessModifier);
+    }
+
+    public Symbol BuildEnum(MemberDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        return new VBEnumMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, SymbolKindExt.Enum,
+            VBUnknownType.TypeInfo, range, range, node.AccessModifier);
+    }
+
+    // Enum members parent to the enum symbol, not the module.
+    public IEnumerable<Symbol> BuildEnumMembers(MemberDeclarationNode enumNode, Uri enumUri)
+    {
+        foreach (var member in enumNode.Children.OfType<ConstantDeclarationNode>())
+        {
+            var range = RangeOf(member);
+            yield return new VBEnumConstMemberSymbol(
+                workspaceRoot, enumUri, member.Name, ScopeKind.Instance, SymbolKindExt.EnumMember, range, range);
+        }
+    }
+
+    public Symbol BuildModuleField(VariableDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        var type = DeclaredType(AsTypeOf(node), node.TypeHint, moduleUri);
+        return new VBModuleFieldVariableMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, type, range, range, node.AccessModifier);
+    }
+
+    public Symbol BuildConstant(ConstantDeclarationNode node)
+    {
+        var range = RangeOf(node);
+        // ConstantDeclarationNode carries no type-hint token; resolve from an As clause if present.
+        var type = DeclaredType(AsTypeOf(node), typeHint: null, moduleUri);
+        return new VBConstantMemberSymbol(
+            workspaceRoot, moduleUri, node.Name, ScopeKind.Instance, type, range, range, node.AccessModifier);
+    }
+
+    // A UDT field parents to the enclosing user-defined-type symbol, not the module.
+    public Symbol BuildUserDefinedTypeField(MemberDeclarationNode node, Uri userDefinedTypeUri)
+    {
+        var range = RangeOf(node);
+        var type = DeclaredType(AsTypeOf(node), typeHint: null, userDefinedTypeUri);
+        return new VBModuleFieldVariableMemberSymbol(
+            workspaceRoot, userDefinedTypeUri, node.Name, type, range, range, node.AccessModifier);
+    }
+
+    private ImmutableArray<VBParameterSymbol> BuildParameters(MemberDeclarationNode member, Uri memberUri)
+    {
+        var parameters = member.Children.OfType<ParameterDeclarationNode>().ToArray();
+        if (parameters.Length == 0)
+        {
+            return [];
+        }
+
+        var builder = ImmutableArray.CreateBuilder<VBParameterSymbol>(parameters.Length);
+        foreach (var parameter in parameters)
+        {
+            var range = RangeOf(parameter);
+            builder.Add(parameter.IsParamArray
+                ? new ParamArrayParameterSymbol(workspaceRoot, memberUri, parameter.Name, range, range, parameter.ParameterKind)
+                : new VBParameterSymbol(
+                    workspaceRoot, memberUri, parameter.Name, range, range, parameter.ParameterKind,
+                    DeclaredType(AsTypeOf(parameter), typeHint: null, memberUri), parameter.IsOptional));
+        }
+        return builder.ToImmutable();
+    }
+
+    private VBType ReturnType(MemberDeclarationNode member, Uri memberUri)
+        => DeclaredType(member.Children.OfType<AsTypeExpressionNode>().FirstOrDefault(), typeHint: null, memberUri);
+
+    private static AsTypeExpressionNode? AsTypeOf(SyntaxNode node)
+        => node.Children.OfType<AsTypeExpressionNode>().FirstOrDefault();
+
+    // A declared type is a name the resolver binds from the given scope. A qualified name or an array
+    // definition needs more than a name lookup, so it is left unresolved for a later semantic pass.
+    private VBType DeclaredType(AsTypeExpressionNode? asType, string? typeHint, Uri handle)
+    {
+        string? typeName = null;
+        if (asType is { QualifierName: null, IsArrayDef: false })
+        {
+            typeName = asType.TypeName;
+        }
+        else if (asType is null && typeHint is not null && _typeHintNames.TryGetValue(typeHint, out var hintName))
+        {
+            typeName = hintName;
+        }
+
+        if (typeName is null)
+        {
+            return VBUnknownType.TypeInfo;
+        }
+
+        return resolver.Resolve(typeName, ScopeKind.Global, handle) switch
+        {
+            BoundTypedSymbol bound => bound.ResolvedType,
+            UnboundTypedSymbol unbound => unbound.ResolvedType,
+            _ => VBUnknownType.TypeInfo,
+        };
+    }
+
+    private static SourceRange RangeOf(SyntaxNode node) => node.SourceLocation.Range;
+}

--- a/RDCore.LanguageServer/Symbols/SyntaxTreeSymbolProvider.cs
+++ b/RDCore.LanguageServer/Symbols/SyntaxTreeSymbolProvider.cs
@@ -1,0 +1,96 @@
+using RDCore.SDK.Model.AST;
+using RDCore.SDK.Model.AST.Declarations;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Runtime.Abstract.Execution;
+
+namespace RDCore.LanguageServer.Symbols;
+
+/// <summary>
+/// Produces the member symbols a module declares, resolved from its parsed declaration AST. Both live
+/// and dead conditional-compilation branches are present in the tree, so both are yielded — the
+/// language server keeps or drops each one once it knows the live <c>#Const</c> values.
+/// </summary>
+/// <remarks>
+/// The containing module symbol is the project symbol provider's responsibility; library reference
+/// symbols are the library symbol provider's. Statement-body locals and user-defined-type fields are
+/// not yielded yet (the parser doesn't emit those nodes).
+/// </remarks>
+internal sealed class SyntaxTreeSymbolProvider(
+    Uri workspaceRoot, Uri moduleUri, ModuleParseResult parseResult, ISymbolResolver resolver) : ISymbolProvider
+{
+    public IEnumerable<Symbol> ProvideSymbols()
+    {
+        if (parseResult.SyntaxTree is not { } module)
+        {
+            yield break;
+        }
+
+        var builder = new SymbolBuilder(workspaceRoot, moduleUri, resolver);
+        foreach (var child in module.Children)
+        {
+            switch (child)
+            {
+                case ExternalMemberDeclarationNode external:
+                    yield return builder.BuildExternal(external);
+                    break;
+
+                case MemberDeclarationNode member:
+                    foreach (var symbol in FromMember(builder, member))
+                    {
+                        yield return symbol;
+                    }
+                    break;
+
+                case VariableDeclarationNode field:
+                    yield return builder.BuildModuleField(field);
+                    break;
+
+                case ConstantDeclarationNode constant when constant.ConstKind == ConstKind.ModuleMember:
+                    yield return builder.BuildConstant(constant);
+                    break;
+            }
+        }
+    }
+
+    private static IEnumerable<Symbol> FromMember(SymbolBuilder builder, MemberDeclarationNode member)
+    {
+        switch (member.MemberKind)
+        {
+            case MemberKind.Procedure:
+                yield return builder.BuildProcedure(member);
+                break;
+            case MemberKind.Function:
+                yield return builder.BuildFunction(member);
+                break;
+            case MemberKind.PropertyGet:
+                yield return builder.BuildPropertyGet(member);
+                break;
+            case MemberKind.PropertyLet:
+                yield return builder.BuildPropertyLet(member);
+                break;
+            case MemberKind.PropertySet:
+                yield return builder.BuildPropertySet(member);
+                break;
+            case MemberKind.Event:
+                yield return builder.BuildEvent(member);
+                break;
+            case MemberKind.UserDefinedType:
+                var userDefinedType = builder.BuildUserDefinedType(member);
+                yield return userDefinedType;
+                foreach (var udtField in member.Children.OfType<MemberDeclarationNode>()
+                    .Where(field => field.MemberKind == MemberKind.UserDefinedTypeField))
+                {
+                    yield return builder.BuildUserDefinedTypeField(udtField, userDefinedType.Uri);
+                }
+                break;
+            case MemberKind.Enum:
+                var enumSymbol = builder.BuildEnum(member);
+                yield return enumSymbol;
+                foreach (var enumConst in builder.BuildEnumMembers(member, enumSymbol.Uri))
+                {
+                    yield return enumConst;
+                }
+                break;
+        }
+    }
+}

--- a/RDCore.LanguageServer/Workspace/Services/ProjectFileService.cs
+++ b/RDCore.LanguageServer/Workspace/Services/ProjectFileService.cs
@@ -51,6 +51,7 @@ internal class ProjectFileService(ILogger<ProjectFileService> logger,
                 _projectFile = project.WithUri(Uri);
 
                 logger.LogInformation("✅ LoadAsync completed. Project file was loaded successfully.");
+                return;
             }
         }
         else

--- a/RDCore.LanguageServer/Workspace/Services/WorkspaceDocumentService.cs
+++ b/RDCore.LanguageServer/Workspace/Services/WorkspaceDocumentService.cs
@@ -55,6 +55,7 @@ internal class WorkspaceDocumentService(IDocumentStateProvider documentStateProv
 
                 var content = await ioFile.ReadAllTextAsync(path);
                 var document = new WorkspaceDocument(relativeUri, _workspaceRoot, content);
+                _documents[document.Id] = document;
 
                 documentStateProvider.OnDocumentLoaded(document.Id);
                 logger.LogInformation("✅ Workspace document was loaded successfully.");

--- a/RDCore.LanguageServer/Workspace/Services/WorkspaceService.cs
+++ b/RDCore.LanguageServer/Workspace/Services/WorkspaceService.cs
@@ -63,6 +63,7 @@ internal class WorkspaceService(Version serverVersion, IServerStateProvider serv
     System.IO.Abstractions.IDirectory ioDirectory,
     IProjectFileService projectFileService,
     IWorkspaceDocumentService documentService,
+    States.IDocumentStateProvider documentStateProvider,
     IEnumerable<SupportedLanguage> supportedLanguages) : IWorkspaceService
 {
     private RDCoreProject ProjectInfo => projectFileService.Project.ProjectInfo!;
@@ -264,6 +265,10 @@ internal class WorkspaceService(Version serverVersion, IServerStateProvider serv
             .Concat(ProjectInfo.OtherFiles)
             .Select(file => new TextDocumentIdentifier(ioPath.Combine(workspaceRoot, file.RelativeUri)))
             .ToList();
+
+        // seed every known document as Unloaded before loading: the document service transitions
+        // state per file and each transition is only valid from a tracked Unloaded state.
+        documentStateProvider.Initialize(files);
 
         await Task.WhenAll(files.Select(documentService.TryLoadAsync));
         if (logger.IsEnabled(LogLevel.Information))

--- a/RDCore.Parsing/AST/DeclarationNodeBuilder.cs
+++ b/RDCore.Parsing/AST/DeclarationNodeBuilder.cs
@@ -84,6 +84,20 @@ internal class DeclarationNodeBuilder(Uri rootUri, SyntaxNodeId nodeId) : NodeBu
             MemberKind.UserDefinedType, 
             modifier);
     }
+    public SyntaxNode BuildUserDefinedTypeMember(VBAParser.UdtMemberContext context)
+    {
+        var name = context.reservedNameMemberDeclaration()?.unrestrictedIdentifier().GetText()
+            ?? context.untypedNameMemberDeclaration().untypedIdentifier().GetText();
+
+        return new MemberDeclarationNode(
+            NodeId,
+            context.GetSourceLocation(_rootUri),
+            [.. _children],
+            name,
+            MemberKind.UserDefinedTypeField,
+            AccessModifier.Implicit);
+    }
+
     public SyntaxNode BuildEnumDeclaration(VBAParser.EnumerationStmtContext context)
     {
         var name = context.identifier().untypedIdentifier()?.GetText()

--- a/RDCore.Parsing/AST/DeclarationsParseTreeListener.cs
+++ b/RDCore.Parsing/AST/DeclarationsParseTreeListener.cs
@@ -140,6 +140,11 @@ internal class DeclarationsParseTreeListener(Uri sourceUri, ModuleNode moduleNod
     public override void ExitUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context)
         => OnExitParent(builder => builder.BuildUserDefinedTypeDeclaration(context));
 
+    public override void EnterUdtMember([NotNull] VBAParser.UdtMemberContext context)
+        => OnEnterParent();
+    public override void ExitUdtMember([NotNull] VBAParser.UdtMemberContext context)
+        => OnExitParent(builder => builder.BuildUserDefinedTypeMember(context));
+
     public override void EnterEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context)
         => OnEnterParent();
     public override void ExitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context)

--- a/RDCore.SDK/Model/Symbols/VBProject/VBConstantMemberSymbol.cs
+++ b/RDCore.SDK/Model/Symbols/VBProject/VBConstantMemberSymbol.cs
@@ -1,0 +1,33 @@
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Source;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Abstract;
+
+namespace RDCore.SDK.Model.Symbols.VBProject;
+
+/// <summary>
+/// A module-level <c>Const</c> declaration. A constant statically evaluates to a value of a fixed
+/// <see cref="VBType"/> and cannot be assigned at run-time; an <c>Enum</c> member is modelled
+/// separately by <see cref="VBEnumConstMemberSymbol"/>.
+/// </summary>
+/// <param name="WorkspaceRoot">The workspace root for this symbol. For an external project or library, this should be different than the user's project workspace.</param>
+/// <param name="ParentUri">The <c>Uri</c> of the parent symbol.</param>
+/// <param name="Name">The identifier name of the symbol.</param>
+/// <param name="Scope">The allocation scope of the symbol.</param>
+/// <param name="ResolvedType">The resolved <see cref="VBType"/> of the constant. Use <see cref="VBUnknownType"/> if the type isn't resolved yet.</param>
+/// <param name="Range">A <c>Range</c> pointing to the document location that belongs to this symbol.</param>
+/// <param name="SelectionRange">A <c>Range</c> pointing to the document location that should be selected when navigating to this symbol.</param>
+/// <param name="AccessModifier">The access modifier specified for this symbol. Use <see cref="AccessModifier.Implicit"/> if none is specified.</param>
+public sealed record class VBConstantMemberSymbol(Uri WorkspaceRoot, Uri ParentUri, string Name, ScopeKind Scope, VBType ResolvedType, SourceRange Range, SourceRange SelectionRange, AccessModifier AccessModifier)
+    : VBReturningMemberSymbol(WorkspaceRoot, ParentUri, Name, Scope, SymbolKindExt.Constant, ResolvedType, Range, SelectionRange, AccessModifier) { }
+
+/// <summary>
+/// A library-provided <c>Const</c> declaration that is not bound to a workspace document location.
+/// </summary>
+/// <param name="WorkspaceRoot">The workspace root for this symbol. For an external project or library, this should be different than the user's project workspace.</param>
+/// <param name="ParentUri">The <c>Uri</c> of the parent symbol.</param>
+/// <param name="Name">The identifier name of the symbol.</param>
+/// <param name="Scope">The allocation scope of the symbol.</param>
+/// <param name="ResolvedType">The resolved <see cref="VBType"/> of the constant. Use <see cref="VBUnknownType"/> if the type isn't resolved yet.</param>
+public sealed record class UnboundVBConstantMemberSymbol(Uri WorkspaceRoot, Uri ParentUri, string Name, ScopeKind Scope, VBType ResolvedType)
+    : UnboundVBReturningMemberSymbol(WorkspaceRoot, ParentUri, Name, Scope, SymbolKindExt.Constant, ResolvedType) { }

--- a/RDCore.Tests/LanguageServer/ParsingClientServiceTests.cs
+++ b/RDCore.Tests/LanguageServer/ParsingClientServiceTests.cs
@@ -16,7 +16,7 @@ namespace RDCore.Tests.LanguageServer;
 [TestClass]
 public sealed class ParsingClientServiceTests
 {
-    private const string Root = @"C:\ws";
+    private static readonly string Root = Path.Combine(Path.GetTempPath(), "rdcore-ws");
 
     private static ModuleParseResult SampleResult
         => new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, "Public Sub Foo()\r\nEnd Sub");

--- a/RDCore.Tests/LanguageServer/ParsingClientServiceTests.cs
+++ b/RDCore.Tests/LanguageServer/ParsingClientServiceTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using RDCore.LanguageServer;
+using RDCore.LanguageServer.Parsing;
+using RDCore.LanguageServer.Workspace;
+using RDCore.LanguageServer.Workspace.Services;
+using RDCore.Parsing;
+using RDCore.SDK.Client;
+using RDCore.SDK.Model.AST;
+using RDCore.SDK.Model.AST.Declarations;
+using RDCore.SDK.Platform.Protocol;
+
+namespace RDCore.Tests.LanguageServer;
+
+[TestClass]
+public sealed class ParsingClientServiceTests
+{
+    private const string Root = @"C:\ws";
+
+    private static ModuleParseResult SampleResult
+        => new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, "Public Sub Foo()\r\nEnd Sub");
+
+    private static (ParsingClientService Sut, IRDCoreClientApp Parser, IWorkspaceDocumentService Documents) Build()
+    {
+        var parser = Substitute.For<IRDCoreClientApp>();
+        parser.WaitForReadyAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        parser.SendRequestAsync<ParseDocumentParams, ModuleParseResult>(default!, default).ReturnsForAnyArgs(SampleResult);
+
+        var orchestration = Substitute.For<IPlatformOrchestrationService>();
+        orchestration.ParsingService.Returns(parser);
+
+        var documents = Substitute.For<IWorkspaceDocumentService>();
+
+        return (new ParsingClientService(orchestration, documents, NullLogger<ParsingClientService>.Instance), parser, documents);
+    }
+
+    [TestMethod]
+    public async Task ParseDocumentAsync_WaitsForReady_SendsRequest_AndCaches()
+    {
+        var (sut, parser, _) = Build();
+        var uri = new Uri("file:///c:/ws/src/Mod1.bas");
+
+        var result = await sut.ParseDocumentAsync(uri, ModuleType.StdModule, CancellationToken.None);
+
+        await parser.Received(1).WaitForReadyAsync(Arg.Any<CancellationToken>());
+        await parser.Received(1).SendRequestAsync<ParseDocumentParams, ModuleParseResult>(
+            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == uri && p.ModuleType == ModuleType.StdModule),
+            Arg.Any<CancellationToken>());
+
+        Assert.IsTrue(sut.TryGetCached(uri, out var cached));
+        Assert.AreSame(result, cached);
+    }
+
+    [TestMethod]
+    public async Task ParseWorkspaceAsync_ParsesEachDocument_WithModuleTypeFromExtension()
+    {
+        var (sut, parser, documents) = Build();
+        var module = new WorkspaceDocument("src/Mod1.bas", Root, "x");
+        var klass = new WorkspaceDocument("src/Cls1.cls", Root, "y");
+        documents.GetAllDocuments().Returns([module, klass]);
+
+        await sut.ParseWorkspaceAsync(CancellationToken.None);
+
+        await parser.Received(1).SendRequestAsync<ParseDocumentParams, ModuleParseResult>(
+            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == module.Id.Uri.ToUri() && p.ModuleType == ModuleType.StdModule),
+            Arg.Any<CancellationToken>());
+        await parser.Received(1).SendRequestAsync<ParseDocumentParams, ModuleParseResult>(
+            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == klass.Id.Uri.ToUri() && p.ModuleType == ModuleType.ClassModule),
+            Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task ParseWorkspaceAsync_DoesNotThrow_WhenAParseRequestFails()
+    {
+        var (sut, parser, documents) = Build();
+        documents.GetAllDocuments().Returns([new WorkspaceDocument("src/Mod1.bas", Root, "x")]);
+        parser.SendRequestAsync<ParseDocumentParams, ModuleParseResult>(default!, default)
+            .ThrowsForAnyArgs(new InvalidOperationException("boom"));
+
+        await sut.ParseWorkspaceAsync(CancellationToken.None);
+    }
+}

--- a/RDCore.Tests/LanguageServer/SyntaxTreeSymbolProviderTests.cs
+++ b/RDCore.Tests/LanguageServer/SyntaxTreeSymbolProviderTests.cs
@@ -1,0 +1,223 @@
+using NSubstitute;
+using RDCore.LanguageServer.Symbols;
+using RDCore.Parsing;
+using RDCore.SDK.Model;
+using RDCore.SDK.Model.AST.Declarations;
+using RDCore.SDK.Model.Source;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Symbols.VBProject;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Runtime.Abstract.Execution;
+
+namespace RDCore.Tests.LanguageServer;
+
+[TestClass]
+public sealed class SyntaxTreeSymbolProviderTests
+{
+    private static readonly Uri WorkspaceRoot = TestUri.WorkspaceRoot();
+    private static readonly Uri ModuleUri = TestUri.TestModuleUri();
+
+    private static List<Symbol> Provide(string source, ISymbolResolver? resolver = null)
+    {
+        var parseResult = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, source);
+        var provider = new SyntaxTreeSymbolProvider(
+            WorkspaceRoot, ModuleUri, parseResult, resolver ?? Substitute.For<ISymbolResolver>());
+        return [.. provider.ProvideSymbols()];
+    }
+
+    private static T Single<T>(IEnumerable<Symbol> symbols) where T : Symbol
+        => symbols.OfType<T>().Single();
+
+    [TestMethod]
+    public void UnparsableModule_YieldsNothing()
+        => Assert.IsEmpty(Provide("not a module"));
+
+    [TestMethod]
+    public void Sub_YieldsProcedureSymbol()
+    {
+        var symbol = Single<VBProcedureMemberSymbol>(Provide("Public Sub Foo()\r\nEnd Sub"));
+
+        Assert.AreEqual("Foo", symbol.Name);
+        Assert.AreEqual(SymbolKindExt.Procedure, symbol.Kind);
+        Assert.AreEqual(AccessModifier.Public, symbol.AccessModifier);
+        Assert.AreEqual(VBTypeNames.VBVoid, symbol.ResolvedType.Name);
+        Assert.IsEmpty(symbol.Parameters);
+    }
+
+    [TestMethod]
+    public void Function_UnresolvedReturnType_StaysUnknown()
+    {
+        var symbol = Single<VBFunctionMemberSymbol>(Provide("Private Function Bar() As Long\r\nEnd Function"));
+
+        Assert.AreEqual("Bar", symbol.Name);
+        Assert.AreEqual(AccessModifier.Private, symbol.AccessModifier);
+        Assert.AreEqual(VBTypeNames.VBUnknown, symbol.ResolvedType.Name);
+    }
+
+    [TestMethod]
+    public void Function_ReturnType_ResolvesThroughSymbolResolver()
+    {
+        var resolver = Substitute.For<ISymbolResolver>();
+        resolver.Resolve("Long", ScopeKind.Global, Arg.Any<Uri>())
+            .Returns(new UnboundVBModuleFieldVariableMemberSymbol(WorkspaceRoot, WorkspaceRoot, "Long", VBLongType.TypeInfo));
+
+        var symbol = Single<VBFunctionMemberSymbol>(Provide("Function Bar() As Long\r\nEnd Function", resolver));
+
+        Assert.IsInstanceOfType<VBLongType>(symbol.ResolvedType);
+    }
+
+    [TestMethod]
+    public void Sub_Parameters_AreYieldedWithKindAndArity()
+    {
+        var symbol = Single<VBProcedureMemberSymbol>(Provide(
+            "Public Sub Baz(ByVal First As Long, Optional Second As String, ParamArray Rest())\r\nEnd Sub"));
+
+        Assert.HasCount(3, symbol.Parameters);
+
+        Assert.AreEqual("First", symbol.Parameters[0].Name);
+        Assert.AreEqual(ParameterKind.ExplicitByVal, symbol.Parameters[0].ParameterKind);
+        Assert.IsFalse(symbol.Parameters[0].IsOptional);
+
+        Assert.AreEqual("Second", symbol.Parameters[1].Name);
+        Assert.IsTrue(symbol.Parameters[1].IsOptional);
+
+        Assert.AreEqual("Rest", symbol.Parameters[2].Name);
+        Assert.IsInstanceOfType<ParamArrayParameterSymbol>(symbol.Parameters[2]);
+
+        // parameters parent to the member, not the module
+        Assert.AreEqual(symbol.Uri, symbol.Parameters[0].ParentUri);
+    }
+
+    [TestMethod]
+    public void ModuleField_YieldsFieldSymbol()
+    {
+        var symbol = Single<VBModuleFieldVariableMemberSymbol>(Provide("Private Amount As Currency"));
+
+        Assert.AreEqual("Amount", symbol.Name);
+        Assert.AreEqual(SymbolKindExt.Field, symbol.Kind);
+        Assert.AreEqual(AccessModifier.Private, symbol.AccessModifier);
+        Assert.AreEqual(ModuleUri, symbol.ParentUri);
+    }
+
+    [TestMethod]
+    public void ConditionalCompilation_YieldsBothLiveAndDeadBranches()
+    {
+        const string source = """
+            #If DEBUG Then
+            Dim Foo As Long
+            Dim Bar As Integer
+            #Else
+            Dim Foo As Double
+            #End If
+            """;
+
+        var fields = Provide(source).OfType<VBModuleFieldVariableMemberSymbol>().ToArray();
+
+        Assert.HasCount(3, fields);
+        Assert.HasCount(2, fields.Where(f => f.Name == "Foo").ToArray());
+    }
+
+    [TestMethod]
+    public void Enum_YieldsEnumSymbolAndItsMembers()
+    {
+        const string source = """
+            Public Enum Color
+                Red
+                Green = 5
+            End Enum
+            """;
+
+        var symbols = Provide(source);
+        var enumSymbol = Single<VBEnumMemberSymbol>(symbols);
+        var members = symbols.OfType<VBEnumConstMemberSymbol>().ToArray();
+
+        Assert.AreEqual("Color", enumSymbol.Name);
+        Assert.AreEqual(SymbolKindExt.Enum, enumSymbol.Kind);
+
+        Assert.HasCount(2, members);
+        CollectionAssert.AreEquivalent(new[] { "Red", "Green" }, members.Select(m => m.Name).ToArray());
+        Assert.AreEqual(enumSymbol.Uri, members[0].ParentUri);
+    }
+
+    [TestMethod]
+    public void DeclareFunction_YieldsExternalFunctionSymbol()
+    {
+        var symbol = Single<VBExternalFunctionMemberSymbol>(Provide(
+            "Public Declare PtrSafe Function GetTickCount Lib \"kernel32\" () As Long"));
+
+        Assert.AreEqual("GetTickCount", symbol.Name);
+        Assert.IsTrue(symbol.IsPtrSafe);
+        Assert.IsTrue(symbol.Lib.Contains("kernel32"));
+        Assert.AreEqual(ScopeKind.External, symbol.ScopeKind);
+    }
+
+    [TestMethod]
+    public void Properties_YieldGetAndLetSymbols()
+    {
+        const string source = """
+            Public Property Get Label() As String
+            End Property
+            Public Property Let Label(ByVal Value As String)
+            End Property
+            """;
+
+        var symbols = Provide(source);
+
+        var getter = Single<VBPropertyGetMemberSymbol>(symbols);
+        var setter = Single<VBPropertyLetMemberSymbol>(symbols);
+        Assert.AreEqual("Label", getter.Name);
+        Assert.AreEqual(SymbolKindExt.Property, getter.Kind);
+        Assert.AreEqual("Label", setter.Name);
+        Assert.HasCount(1, setter.Parameters);
+    }
+
+    [TestMethod]
+    public void Event_YieldsEventSymbol()
+    {
+        var symbol = Single<VBEventMemberSymbol>(Provide("Public Event Changed(ByVal NewValue As Long)"));
+
+        Assert.AreEqual("Changed", symbol.Name);
+        Assert.AreEqual(SymbolKindExt.Event, symbol.Kind);
+    }
+
+    [TestMethod]
+    public void ModuleConst_YieldsConstantSymbol()
+    {
+        var symbol = Single<VBConstantMemberSymbol>(Provide("Public Const MaxItems As Long = 10"));
+
+        Assert.AreEqual("MaxItems", symbol.Name);
+        Assert.AreEqual(SymbolKindExt.Constant, symbol.Kind);
+        Assert.AreEqual(AccessModifier.Public, symbol.AccessModifier);
+    }
+
+    [TestMethod]
+    public void UserDefinedType_YieldsTypeSymbolAndItsFields()
+    {
+        const string source = """
+            Public Type TPoint
+                X As Long
+                Y As Long
+            End Type
+            """;
+
+        var symbols = Provide(source);
+        var type = Single<VBUserDefinedTypeMemberSymbol>(symbols);
+        var fields = symbols.OfType<VBModuleFieldVariableMemberSymbol>().ToArray();
+
+        Assert.AreEqual("TPoint", type.Name);
+        Assert.AreEqual(SymbolKindExt.UserDefinedType, type.Kind);
+
+        Assert.HasCount(2, fields);
+        CollectionAssert.AreEquivalent(new[] { "X", "Y" }, fields.Select(f => f.Name).ToArray());
+        Assert.AreEqual(type.Uri, fields[0].ParentUri);
+    }
+
+    [TestMethod]
+    public void Symbol_RangeComesFromTheDeclarationNode()
+    {
+        var symbol = Single<VBProcedureMemberSymbol>(Provide("Sub Foo()\r\nEnd Sub"));
+
+        Assert.AreNotEqual(SourceRange.Empty, symbol.Range);
+        Assert.AreEqual(symbol.Range, symbol.SelectionRange);
+    }
+}

--- a/RDCore.Tests/LanguageServer/WorkspaceLoaderTests.cs
+++ b/RDCore.Tests/LanguageServer/WorkspaceLoaderTests.cs
@@ -1,0 +1,111 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using RDCore.LanguageServer.Server;
+using RDCore.LanguageServer.Workspace.Services;
+using RDCore.LanguageServer.Workspace.States;
+using RDCore.SDK.Server.Services.States;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Tests.LanguageServer;
+
+[TestClass]
+public sealed class WorkspaceLoaderTests
+{
+    private const string Root = @"C:\ws";
+    private static readonly string ProjectFilePath = Path.Combine(Root, ProjectFile.FileName);
+
+    private static MockFileSystem FileSystemWith(params (string RelativePath, string Content)[] files)
+    {
+        var project = new ProjectFile(Root, new RDCoreProject
+        {
+            Modules = [.. files.Select(f => new RDCoreModule { RelativeUri = f.RelativePath })],
+        });
+
+        var entries = new Dictionary<string, MockFileData>
+        {
+            [ProjectFilePath] = new MockFileData(JsonSerializer.Serialize(project)),
+        };
+        foreach (var (relativePath, content) in files)
+        {
+            entries[Path.Combine(Root, relativePath)] = new MockFileData(content);
+        }
+        return new MockFileSystem(entries);
+    }
+
+    private static ProjectFileService ProjectService(MockFileSystem fs)
+        => new(NullLogger<ProjectFileService>.Instance, fs.Path, fs.File);
+
+    private static IServerStateProvider InitializingState()
+    {
+        var state = Substitute.For<IServerStateProvider>();
+        state.State.Returns(ServerState.Initializing);
+        return state;
+    }
+
+    private static WorkspaceService WorkspaceService(MockFileSystem fs, IServerStateProvider? state = null)
+    {
+        var documentStates = new DocumentStateProvider(NullLogger<DocumentStateProvider>.Instance);
+        var documents = new WorkspaceDocumentService(
+            documentStates, NullLogger<WorkspaceDocumentService>.Instance, fs.Path, fs.File);
+
+        return new WorkspaceService(
+            new Version(99, 0, 0), state ?? InitializingState(), NullLogger<WorkspaceService>.Instance,
+            fs.Path, fs.File, fs.Directory, ProjectService(fs), documents, documentStates,
+            [ProtocolSupportedLanguage.VBA]);
+    }
+
+    [TestMethod]
+    public async Task ProjectFileService_LoadAsync_Success_SetsProjectAndReturns()
+    {
+        var fs = FileSystemWith(("src/Mod1.bas", "Attribute VB_Name = \"Mod1\""));
+        var sut = ProjectService(fs);
+
+        await sut.LoadAsync(Root);
+
+        Assert.AreEqual(Root, sut.Project.Uri);
+        Assert.ContainsSingle(sut.Project.ProjectInfo.Modules);
+        Assert.AreEqual("src/Mod1.bas", sut.Project.ProjectInfo.Modules[0].RelativeUri);
+    }
+
+    [TestMethod]
+    public async Task ProjectFileService_LoadAsync_NoProjectFile_Throws()
+    {
+        var sut = ProjectService(new MockFileSystem());
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => sut.LoadAsync(Root));
+    }
+
+    [TestMethod]
+    public async Task WorkspaceService_LoadAsync_LoadsModuleContent_AndMarksItLoaded()
+    {
+        var fs = FileSystemWith(("src/Mod1.bas", "Public Sub Foo()\r\nEnd Sub"));
+        var documentStates = new DocumentStateProvider(NullLogger<DocumentStateProvider>.Instance);
+        var documents = new WorkspaceDocumentService(
+            documentStates, NullLogger<WorkspaceDocumentService>.Instance, fs.Path, fs.File);
+
+        var sut = new WorkspaceService(
+            new Version(99, 0, 0), InitializingState(), NullLogger<WorkspaceService>.Instance,
+            fs.Path, fs.File, fs.Directory, ProjectService(fs), documents, documentStates,
+            [ProtocolSupportedLanguage.VBA]);
+
+        await sut.LoadAsync(Root);
+
+        var loaded = documents.GetAllDocuments().ToArray();
+        Assert.ContainsSingle(loaded);
+        Assert.AreEqual("Public Sub Foo()\r\nEnd Sub", loaded[0].Text);
+        Assert.IsInstanceOfType<LoadedDocumentState>(documentStates.GetCurrentState(loaded[0].Id));
+    }
+
+    [TestMethod]
+    public async Task WorkspaceService_LoadAsync_NotInitializing_Throws()
+    {
+        var state = Substitute.For<IServerStateProvider>();
+        state.State.Returns(ServerState.Running);
+
+        var sut = WorkspaceService(FileSystemWith(("src/Mod1.bas", "")), state);
+
+        await Assert.ThrowsExactlyAsync<InvalidServerStateException>(() => sut.LoadAsync(Root));
+    }
+}

--- a/RDCore.Tests/LanguageServer/WorkspaceLoaderTests.cs
+++ b/RDCore.Tests/LanguageServer/WorkspaceLoaderTests.cs
@@ -13,7 +13,8 @@ namespace RDCore.Tests.LanguageServer;
 [TestClass]
 public sealed class WorkspaceLoaderTests
 {
-    private const string Root = @"C:\ws";
+    // an absolute path the MockFileSystem accepts on both Windows and the Linux CI runner.
+    private static readonly string Root = Path.Combine(Path.GetTempPath(), "rdcore-ws");
     private static readonly string ProjectFilePath = Path.Combine(Root, ProjectFile.FileName);
 
     private static MockFileSystem FileSystemWith(params (string RelativePath, string Content)[] files)

--- a/RDCore.Tests/Parser/DeclarationPassParserTests.cs
+++ b/RDCore.Tests/Parser/DeclarationPassParserTests.cs
@@ -199,6 +199,31 @@ End Sub
         Assert.AreEqual((short)42, ((VBIntegerValue)literal.StaticValue).Value);
     }
 
+    [TestMethod]
+    public void UserDefinedType_EmitsMemberFieldNodes()
+    {
+        const string content = """
+            Public Type TPoint
+                X As Long
+                Y As String
+            End Type
+            """;
+
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
+
+        var udt = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>()
+            .Single(member => member.MemberKind == MemberKind.UserDefinedType);
+        var fields = udt.Children.OfType<MemberDeclarationNode>()
+            .Where(member => member.MemberKind == MemberKind.UserDefinedTypeField)
+            .ToArray();
+
+        Assert.HasCount(2, fields);
+        Assert.AreEqual("X", fields[0].Name);
+        Assert.AreEqual("Y", fields[1].Name);
+        Assert.HasCount(1, fields[0].Children.OfType<AsTypeExpressionNode>());
+    }
+
     private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
     {
         foreach (var child in node.Children)

--- a/docs/specs/rd-vbal.2.3.application-host.md
+++ b/docs/specs/rd-vbal.2.3.application-host.md
@@ -44,10 +44,12 @@ The read face used by the static and runtime semantic layers is `ISymbolResolver
 |`GetValue`|Gets the `IBindingHandle` currently bound to a specified `Symbol`|
 |`TryRead`|Gets the `IBindingHandle` held at a specified `MemoryAddress`, if any|
 
-`ISymbolProvider` exposes a single `Define` method that loads a specified `Symbol` into the semantic
-layer (static context) or the session symbol table (runtime context). It is the abstraction behind the
-several _symbol providers_ a session is composed from — configuration flags, AST declarations,
-reflected referenced libraries, and the environment host's own runtime and standard library.
+`ISymbolProvider` exposes a single `ProvideSymbols` method that yields the `Symbol`s its source
+defines; the composition root then defines each one into the semantic layer (static context) or the
+session symbol table (runtime context, through `ISessionSymbols.TryDefine`). It is the abstraction
+behind the several _symbol providers_ a session is composed from — configuration flags, AST
+declarations, reflected referenced libraries, and the environment host's own runtime and standard
+library.
 
 > [!NOTE]
 > Where a `Symbol`'s bound value lives is being moved to an addressable _session storage_ — a


### PR DESCRIPTION
- SyntaxTreeSymbolProvider + SymbolBuilder (RDCore.LanguageServer/Symbols): ModuleParseResult -> bound member symbols (proc/func/property/field/Const/ Declare/Event/Enum+members/Type+fields); declared types resolved through an injected ISymbolResolver (returns null today -> VBUnknownType, call path is permanent). Both live + dead #If branches emitted.
- new SDK symbol VBConstantMemberSymbol (+Unbound).
- parser: emit UDT member field nodes (Enter/ExitUdtMember + DeclarationNodeBuilder.BuildUserDefinedTypeMember) -> MemberDeclarationNode (MemberKind.UserDefinedTypeField). Closes the "missing UDT member nodes" gap.
- load the .rdproj and module contents on LSP initialize: register the Workspace/Services tree, fix ProjectFileService.LoadAsync throwing on the success path, seed IDocumentStateProvider before loading, add loaded docs to the document store.
- ParsingClientService: rdcore/parser/document round-trip + per-document AST cache, driven as a supervised task from OnLanguageServerStarted. Adds InternalsVisibleTo("DynamicProxyGenAssembly2") to the LS.
- docs: correct the ISymbolProvider description in rd-vbal.2.3 (ProvideSymbols, not a Define method).