### PR TITLE
stdlib: revert the module interfaces to semantic value-type signatures

### DIFF
--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdCollectionClass.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdCollectionClass.cs
@@ -1,5 +1,4 @@
 ﻿using RDCore.SDK.Model.Errors;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Model.Values.Intrinsic;
 using RDCore.SDK.Runtime.Shared;
 
@@ -27,7 +26,7 @@ public interface IStdCollectionClass
     /// </remarks>
     /// <param name="index"></param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdCollectionClass__Item(VBRuntimeVariantValue index);
+    RuntimeSemanticsEvaluationResult StdCollectionClass__Item(VBVariantValue index);
     #endregion
 
     #region 6.1.3.2 Public Procedures
@@ -45,7 +44,7 @@ public interface IStdCollectionClass
     /// <param name="after">An expression that specifies a relative position in the collection; the item to be added is placed <em>after</em> the item identified by this parameter.<br/>
     /// 💥<see cref="VBRuntimeErrorId.InvalidProcedureCallOrArgument"/> if <strong>both</strong> <em>before</em> and <em>after</em> optional parameters are specified, or if they refer to non-existing items.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdCollectionClass__Add(VBRuntimeVariantValue item, VBRuntimeVariantValue? key = default, VBRuntimeVariantValue? before = default, VBRuntimeVariantValue? after = default);
+    RuntimeSemanticsEvaluationResult StdCollectionClass__Add(VBVariantValue item, VBVariantValue? key = default, VBVariantValue? before = default, VBVariantValue? after = default);
 
     /// <summary>
     /// Removes an item from the collection.
@@ -53,6 +52,6 @@ public interface IStdCollectionClass
     /// <param name="index">The <em>key</em> or <em>positional index</em> of the item to be removed.<br/>
     /// 💥<see cref="VBRuntimeErrorId.MethodOrDataMemberNotFound"/> if no item exists at the specified positional index or with the specified key.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdCollectionClass__Remove(VBRuntimeVariantValue index);
+    RuntimeSemanticsEvaluationResult StdCollectionClass__Remove(VBVariantValue index);
     #endregion
 }

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdConversionModule.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdConversionModule.cs
@@ -1,6 +1,5 @@
 ﻿using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Model.Values.Intrinsic;
 using RDCore.SDK.Runtime.Shared;
 
@@ -22,7 +21,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CBool(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CBool(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.2 CByte</strong>
@@ -32,7 +31,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CByte(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CByte(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.3 CCur</strong>
@@ -42,7 +41,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CCur(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CCur(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.4 CDate</strong>
@@ -52,7 +51,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CDate(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CDate(VBVariantValue expression);
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.4 CVDate</strong>
     /// </summary>
@@ -61,7 +60,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CVDate(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CVDate(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.5 CDbl</strong>
@@ -71,7 +70,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CDbl(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CDbl(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.6 CDec</strong>
@@ -81,7 +80,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CDec(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CDec(VBVariantValue expression);
 
 
     /// <summary>
@@ -92,7 +91,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CInt(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CInt(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.8 CLng</strong>
@@ -102,7 +101,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CLng(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CLng(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.9 CLngLng</strong>
@@ -113,7 +112,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CLngLng(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CLngLng(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.10 CLngPtr</strong>
@@ -124,7 +123,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CLngPtr(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CLngPtr(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.11 CSng</strong>
@@ -134,7 +133,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CSng(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CSng(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.12 CStr</strong>
@@ -144,7 +143,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CStr(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CStr(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.13 CVar</strong>
@@ -154,7 +153,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CVar(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CVar(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.14 CVErr</strong>
@@ -164,7 +163,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__CVErr(VBRuntimeVariantValue expression);
+    RuntimeSemanticsEvaluationResult StdConversions__CVErr(VBVariantValue expression);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.15 Error</strong>
@@ -174,7 +173,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Error(VBRuntimeVariantValue errorNumber);
+    RuntimeSemanticsEvaluationResult StdConversions__Error(VBVariantValue errorNumber);
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.15 Error$</strong>
     /// </summary>
@@ -183,7 +182,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__ErrorStr(VBRuntimeVariantValue errorNumber);
+    RuntimeSemanticsEvaluationResult StdConversions__ErrorStr(VBVariantValue errorNumber);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.16 Fix</strong>
@@ -193,7 +192,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Fix(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__Fix(VBVariantValue number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.17 Hex</strong>
@@ -203,7 +202,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Hex(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__Hex(VBVariantValue number);
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.17 Hex$</strong>
     /// </summary>
@@ -212,7 +211,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__HexStr(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__HexStr(VBVariantValue number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.18 Int</strong>
@@ -222,7 +221,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Int(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__Int(VBVariantValue number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.19 Oct</strong>
@@ -232,7 +231,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Oct(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__Oct(VBVariantValue number);
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.19 Oct$</strong>
     /// </summary>
@@ -241,7 +240,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__OctStr(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__OctStr(VBVariantValue number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.20 Str</strong>
@@ -251,7 +250,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Str(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__Str(VBVariantValue number);
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.20 Str$</strong>
     /// </summary>
@@ -260,7 +259,7 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__StrStr(VBRuntimeVariantValue number);
+    RuntimeSemanticsEvaluationResult StdConversions__StrStr(VBVariantValue number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.3.1.21 Val</strong>
@@ -270,5 +269,5 @@ public interface IStdConversionModule
     /// </remarks>
     /// <param name="expression">Any <em>data value</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdConversions__Val(string value);
+    RuntimeSemanticsEvaluationResult StdConversions__Val(VBStringValue value);
 }

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdErrClass.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdErrClass.cs
@@ -1,6 +1,5 @@
 ﻿using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Values.Intrinsic;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Runtime.Abstract.StdLib;
@@ -40,7 +39,7 @@ public interface IStdErrClass
     /// <param name="helpFile">ℹ️ Unsupported legacy proprietary Microsoft help system. This parameter is <strong>out of scope</strong> of this implementation.</param>
     /// <param name="helpContext">ℹ️ Unsupported legacy proprietary Microsoft help system. This parameter is <strong>out of scope</strong> of this implementation.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdErrClass__Raise(VBRuntimeValue<Int32> number, VBRuntimeVariantValue source, VBVariantValue description, VBVariantValue? helpFile = default, VBVariantValue? helpContext = default);
+    public RuntimeSemanticsEvaluationResult StdErrClass__Raise(VBLongValue number, VBVariantValue source, VBVariantValue description, VBVariantValue? helpFile = default, VBVariantValue? helpContext = default);
     #endregion
 
     #region 6.1.3.2.2 Public Properties
@@ -53,7 +52,7 @@ public interface IStdErrClass
     /// </summary>
     /// <param name="value">A <see cref="VBStringValue"/> containing a description of the error.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdErrClass_setDescription(VBRuntimeReference value);
+    public RuntimeSemanticsEvaluationResult StdErrClass_setDescription(VBStringValue value);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.3.2.2 HelpContext</strong> Gets a <see cref="VBStringValue"/> containing the <em>HelpContextID</em> of the error.
@@ -71,7 +70,7 @@ public interface IStdErrClass
     /// ℹ️ Unsupported legacy proprietary Microsoft help system. This property is <strong>out of scope</strong> of this implementation.
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdErrClass_setHelpContext(VBRuntimeReference value);
+    public RuntimeSemanticsEvaluationResult StdErrClass_setHelpContext(VBStringValue value);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.3.2.3 HelpFile</strong> Gets a <see cref="VBStringValue"/> containing the <em>HelpFile</em> of the error.
@@ -89,7 +88,7 @@ public interface IStdErrClass
     /// ℹ️ Unsupported legacy proprietary Microsoft help system. This property is <strong>out of scope</strong> of this implementation.
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdErrClass_setHelpFile(VBRuntimeReference value);
+    public RuntimeSemanticsEvaluationResult StdErrClass_setHelpFile(VBStringValue value);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.3.2.4 LastDllError</strong> Gets a <see cref="VBLongValue"/> containing a <em>system error code</em> produced by a call to a <em>dynamic-link library</em> (DLL).
@@ -112,6 +111,6 @@ public interface IStdErrClass
     /// <strong>MS-VBAL 6.1.3.2.2.5 Number</strong> Sets a <see cref="VBLongValue"/> containing an error code.
     /// </summary>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdErrClass_setNumber(VBRuntimeValue<Int32> value);
+    public RuntimeSemanticsEvaluationResult StdErrClass_setNumber(VBLongValue value);
     #endregion
 }

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdGlobalClass.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdGlobalClass.cs
@@ -1,5 +1,4 @@
 ﻿using RDCore.SDK.Model.Values.Intrinsic;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Runtime.Abstract.StdLib;
@@ -28,12 +27,12 @@ public interface IStdGlobalClass
     /// </list>
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdGlobalClass_Load(VBRuntimeReference value);
+    public RuntimeSemanticsEvaluationResult StdGlobalClass_Load(VBObjectValue value);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.3.3.1.2 Unload</strong> Unloads a <em>form</em> or <em>control</em> from memory.<br/>
     /// </summary>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    public RuntimeSemanticsEvaluationResult StdGlobalClass_Unload(VBRuntimeReference value);
+    public RuntimeSemanticsEvaluationResult StdGlobalClass_Unload(VBObjectValue value);
     #endregion
 }

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdInformationModule.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdInformationModule.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Intrinsic;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Runtime.Abstract.StdLib;
@@ -106,7 +105,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsArray(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsArray(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.3 IsDate</strong>
@@ -116,7 +115,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsDate(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsDate(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.4 IsEmpty</strong>
@@ -126,7 +125,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsEmpty(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsEmpty(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.5 IsError</strong>
@@ -136,7 +135,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsError(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsError(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.6 IsMissing</strong>
@@ -147,7 +146,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsMissing(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsMissing(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.7 IsNull</strong>
@@ -157,7 +156,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsNull(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsNull(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.8 IsNumeric</strong>
@@ -167,7 +166,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsNumeric(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsNumeric(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.9 IsObject</strong>
@@ -177,7 +176,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__IsObject(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__IsObject(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.10 QBColor</strong>
@@ -187,7 +186,7 @@ public interface IStdInformationModule
     /// </remarks>
     /// <param name="arg">The data value to be tested</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__QBColor(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__QBColor(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.11 RGB</strong>
@@ -199,7 +198,7 @@ public interface IStdInformationModule
     /// <param name="green">A value in the <see cref="VBByteValue"/> range (0-255) representing the <strong>green</strong> component of the color.</param>
     /// <param name="blue">A value in the <see cref="VBByteValue"/> range (0-255) representing the <strong>blue</strong> component of the color.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__RGB(VBRuntimeValue<Int16> red, VBRuntimeValue<Int16> green, VBRuntimeValue<Int16> blue);
+    RuntimeSemanticsEvaluationResult StdInformation__RGB(VBIntegerValue red, VBIntegerValue green, VBIntegerValue blue);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.12 TypeName</strong>
@@ -209,7 +208,7 @@ public interface IStdInformationModule
     /// 👉 If the provided value is a <see cref="VBArrayValue"/>, the returned string contains the <em>item data type</em> of the array appended with a pair of empty parentheses, e.g. <c>"Byte()"</c> for an array of <see cref="VBByteValue"/> items.
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__TypeName(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__TypeName(VBVariantValue arg);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.7.1.13 VarType</strong>
@@ -219,6 +218,6 @@ public interface IStdInformationModule
     /// 👉 If the provided value is a <see cref="VBArrayValue"/>, the returned string contains the <em>item data type</em> of the array appended with a pair of empty parentheses, e.g. <c>"Byte()"</c> for an array of <see cref="VBByteValue"/> items.
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInformation__VarType(VBRuntimeVariantValue arg);
+    RuntimeSemanticsEvaluationResult StdInformation__VarType(VBVariantValue arg);
     #endregion
 }

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdInteractionModule.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdInteractionModule.cs
@@ -1,6 +1,5 @@
 ﻿using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Values.Intrinsic;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Runtime.Abstract.StdLib;
@@ -27,7 +26,7 @@ public interface IStdInteractionModule
     /// <param name="callType">The type of member invocation.</param>
     /// <param name="args">Any arguments to be supplied to the member upon invocation.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__CallByName(VBRuntimeReference objectValue, string procName, VBCallType callType, params VBRuntimeVariantValue[] args);
+    RuntimeSemanticsEvaluationResult StdInteraction__CallByName(VBObjectValue objectValue, string procName, VBCallType callType, params VBVariantValue[] args);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.2 Choose</strong>
@@ -40,7 +39,7 @@ public interface IStdInteractionModule
     /// <param name="index">An <see cref="VBIntegerValue"/> between 1 and the number of supplied choices.</param>
     /// <param name="choice">An array containing the values to choose from.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__Choose(VBRuntimeValue<Single> index, params VBRuntimeVariantValue[] choice);
+    RuntimeSemanticsEvaluationResult StdInteraction__Choose(VBSingleValue index, params VBVariantValue[] choice);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.3 Command</strong>
@@ -68,7 +67,7 @@ public interface IStdInteractionModule
     /// <param name="objectClass">A <see cref="VBStringValue"/> containing the <em>application name and class</em> of the object to create.</param>
     /// <param name="serverName">A <see cref="VBStringValue"/> containing the name of the network server where the object will be created.<br/><strong>Optional</strong>: the <em>local machine</em> is used unless specified otherwise.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__CreateObject(VBRuntimeReference objectClass, VBRuntimeReference? serverName = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__CreateObject(VBStringValue objectClass, VBStringValue? serverName = default);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.5 DoEvents</strong>
@@ -88,7 +87,7 @@ public interface IStdInteractionModule
     /// </remarks>
     /// <param name="key">A <see cref="VBStringValue"/>, or a data value that is let-coercible to <see cref="VBLongValue"/>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__VEnviron(VBRuntimeVariantValue key);
+    RuntimeSemanticsEvaluationResult StdInteraction__VEnviron(VBVariantValue key);
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.6 Environ$</strong>
     /// </summary>
@@ -97,7 +96,7 @@ public interface IStdInteractionModule
     /// </remarks>
     /// <param name="key">A <see cref="VBStringValue"/>, or a data value that is let-coercible to <see cref="VBLongValue"/>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__SEnviron(VBRuntimeVariantValue key);
+    RuntimeSemanticsEvaluationResult StdInteraction__SEnviron(VBVariantValue key);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.7 GetAllSettings</strong>
@@ -109,7 +108,7 @@ public interface IStdInteractionModule
     /// <param name="appName">A <see cref="VBStringValue"/> expression containing the name of the application or project whose key settings are requested.</param>
     /// <param name="section">A <see cref="VBStringValue"/> expression containing the name of the configuration section whose key settings are requested.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__GetAllSettings(VBRuntimeReference appName, VBRuntimeReference section);
+    RuntimeSemanticsEvaluationResult StdInteraction__GetAllSettings(VBStringValue appName, VBStringValue section);
     /// <summary>
     /// 🧩 <strong>RD-VBAL 6.1.2.8.1.7.1 GetJsonSettings</strong><br/>
     /// </summary>
@@ -120,7 +119,7 @@ public interface IStdInteractionModule
     /// <param name="key">A <see cref="VBStringValue"/> expression containing the <em>managed configuration path</em> (e.g. <c>"Configuration:ConnectionStrings"</c>) of the configuration section whose key settings are requested.</param>
     /// <param name="config">A <see cref="VBStringValue"/> expression containing the <strong>name of a .json configuration file</strong> associated with the <em>workspace application</em>.<br/><strong>Optional</strong>: The default value of this parameter depends on the current host configuration (normally <c>"appsettings.json"</c>).</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__GetJsonSettings(VBRuntimeReference key, VBRuntimeReference? config = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__GetJsonSettings(VBStringValue key, VBStringValue? config = default);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.8 GetAttr</strong>
@@ -130,7 +129,7 @@ public interface IStdInteractionModule
     /// </remarks>
     /// <param name="pathName">A <see cref="VBStringValue"/> expression containing a file name. May specify a <em>mapped drive</em> and/or a <em>directory/folder path</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__GetAttr(VBRuntimeReference pathName);
+    RuntimeSemanticsEvaluationResult StdInteraction__GetAttr(VBStringValue pathName);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.9 GetObject</strong>
@@ -143,7 +142,7 @@ public interface IStdInteractionModule
     /// <param name="pathName">A <see cref="VBStringValue"/> expression containing the name of the <em>network server</em> where the object will be created.<br/><strong>Optional</strong>: the <em>local machine</em> is used unless specified otherwise.</param>
     /// <param name="className">A <em>qualified</em> <see cref="VBStringValue"/> expression containing the <em>application name</em> and <em>class</em> of the object to create.<br/><strong>Optional</strong> (⚠️ but raises an error given <see cref="VBMissingValue"/>): returns the singleton instance of (the last created) <em>single-instance object</em> given an <em>empty string</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__GetObject(VBRuntimeVariantValue? pathName = default, VBRuntimeVariantValue? className = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__GetObject(VBVariantValue? pathName = default, VBVariantValue? className = default);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.10 GetSetting</strong>
@@ -156,7 +155,7 @@ public interface IStdInteractionModule
     /// <param name="key">A <see cref="VBStringValue"/> expression containing the <em>key</em> of the requested <em>key setting</em> value.</param>
     /// <param name="defaultValue">A <see cref="VBVariantValue"/> expression containing the value to return if no value is set in the key setting.<br/><strong>Optional</strong>: defaults to <see cref="VBStringValue.ZeroLengthString"/>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__GetSetting(VBRuntimeReference appName, VBRuntimeReference section, VBRuntimeReference key, VBRuntimeVariantValue? defaultValue = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__GetSetting(VBStringValue appName, VBStringValue section, VBStringValue key, VBVariantValue? defaultValue = default);
     /// <summary>
     /// 🧩 <strong>RD-VBAL 6.1.2.8.1.10.1 GetJsonSetting</strong><br/>
     /// </summary>
@@ -167,7 +166,7 @@ public interface IStdInteractionModule
     /// <param name="config">A <see cref="VBStringValue"/> expression containing the <strong>name of a .json configuration file</strong> associated with the <em>workspace application</em>.<br/><strong>Optional</strong>: The default value of this parameter depends on the current host configuration (normally <c>"appsettings.json"</c>).</param>
     /// <param name="defaultValue">A <see cref="VBVariantValue"/> expression containing the value to return if no value is set in the key setting.<br/><strong>Optional</strong>: defaults to <see cref="VBStringValue.ZeroLengthString"/>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__GetJsonSetting(VBRuntimeReference key, VBRuntimeReference? config = default, VBRuntimeVariantValue? defaultValue = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__GetJsonSetting(VBStringValue key, VBStringValue? config = default, VBVariantValue? defaultValue = default);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.11 IIf</strong>
@@ -179,7 +178,7 @@ public interface IStdInteractionModule
     /// </remarks>
     /// <param name="pathName">A <see cref="VBStringValue"/> expression containing a file name. May specify a <em>mapped drive</em> and/or a <em>directory/folder path</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__IIf(VBRuntimeVariantValue expression, VBRuntimeVariantValue truePart, VBRuntimeVariantValue falsePart);
+    RuntimeSemanticsEvaluationResult StdInteraction__IIf(VBVariantValue expression, VBVariantValue truePart, VBVariantValue falsePart);
     
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.12 InputBox</strong>
@@ -195,7 +194,7 @@ public interface IStdInteractionModule
     /// <param name="helpFile">ℹ️ Unsupported legacy proprietary Microsoft help system. This parameter is <strong>out of scope</strong> of this implementation.</param>
     /// <param name="helpContext">ℹ️ Unsupported legacy proprietary Microsoft help system. This parameter is <strong>out of scope</strong> of this implementation.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__InputBox(VBRuntimeVariantValue prompt, VBRuntimeVariantValue? title = default, VBRuntimeVariantValue? defaultValue = default, VBRuntimeVariantValue? xpos = default, VBRuntimeVariantValue? ypos = default, VBRuntimeVariantValue? helpFile = default, VBRuntimeVariantValue? helpContext = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__InputBox(VBVariantValue prompt, VBVariantValue? title = default, VBVariantValue? defaultValue = default, VBVariantValue? xpos = default, VBVariantValue? ypos = default, VBVariantValue? helpFile = default, VBVariantValue? helpContext = default);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.13 MsgBox</strong>
@@ -209,7 +208,7 @@ public interface IStdInteractionModule
     /// <param name="helpFile">ℹ️ Unsupported legacy proprietary Microsoft help system. This parameter is <strong>out of scope</strong> of this implementation.</param>
     /// <param name="helpContext">ℹ️ Unsupported legacy proprietary Microsoft help system. This parameter is <strong>out of scope</strong> of this implementation.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__MsgBox(VBRuntimeVariantValue prompt, VBMsgBoxStyle buttons = VBMsgBoxStyle.VBDefaultButton1, VBRuntimeVariantValue? title = default, VBRuntimeVariantValue? helpFile = default, VBRuntimeVariantValue? helpContext = default);
+    RuntimeSemanticsEvaluationResult StdInteraction__MsgBox(VBVariantValue prompt, VBMsgBoxStyle buttons = VBMsgBoxStyle.VBDefaultButton1, VBVariantValue? title = default, VBVariantValue? helpFile = default, VBVariantValue? helpContext = default);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.14 Partition</strong>
@@ -222,7 +221,7 @@ public interface IStdInteractionModule
     /// <param name="stop">A <see cref="VBLongValue"/> expression containing the <strong>end</strong> of the overall range of numbers.<br/>👉 The numeric value of this parameter <strong>cannot be less than or equal to</strong> the <c>start</c> value 💥<see cref="VBRuntimeErrorId.InvalidProcedureCallOrArgument"/>.</param>
     /// <param name="interval">A <see cref="VBLongValue"/> expression containing the <strong>interval</strong> of each range of numbers.<br/>👉 The numeric value of this parameter <strong>cannot be less than</strong> <c>1</c> 💥<see cref="VBRuntimeErrorId.InvalidProcedureCallOrArgument"/>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__Partition(VBRuntimeVariantValue number, VBRuntimeVariantValue start, VBRuntimeVariantValue stop, VBRuntimeVariantValue interval);
+    RuntimeSemanticsEvaluationResult StdInteraction__Partition(VBVariantValue number, VBVariantValue start, VBVariantValue stop, VBVariantValue interval);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.15 Shell</strong>
@@ -233,7 +232,7 @@ public interface IStdInteractionModule
     /// <param name="path">A <see cref="VBStringValue"/> expression containing the <em>value</em> to be evaluated against the <em>range</em>.</param>
     /// <param name="windowStyle">A <see cref="VBIntegerValue"/> (<see cref="VBAppWinStyle"/>) expression containing a value that sets the <em>style</em> of the window in which the program is to be executed.<br/><strong>Optional</strong>: <see cref="VBAppWinStyle.VBMinimizedFocus"/> unless specified otherwise.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__Shell(VBRuntimeVariantValue path, VBAppWinStyle windowStyle = VBAppWinStyle.VBMinimizedFocus);
+    RuntimeSemanticsEvaluationResult StdInteraction__Shell(VBVariantValue path, VBAppWinStyle windowStyle = VBAppWinStyle.VBMinimizedFocus);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.8.1.16 Switch</strong>
@@ -251,7 +250,7 @@ public interface IStdInteractionModule
     /// </remarks>
     /// <param name="varExpr">A <see cref="VBArrayValue"/> containing <see cref="VBVariantValue"/> elements representing expressions to be evaluated.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdInteraction__Switch(params VBRuntimeVariantValue[] varExpr);
+    RuntimeSemanticsEvaluationResult StdInteraction__Switch(params VBVariantValue[] varExpr);
     #endregion
 
     #region 6.1.2.8.2. Public Subroutines

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdMathModule.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdMathModule.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Intrinsic;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Runtime.Abstract.StdLib;
@@ -24,7 +23,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <em>data value</em></param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Abs(VBRuntimeVariantValue Number);
+    RuntimeSemanticsEvaluationResult StdMath__Abs(VBVariantValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.2 Atn</strong>
@@ -34,7 +33,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>).</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Atn(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Atn(VBDoubleValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.3 Cos</strong>
@@ -44,7 +43,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>) <em>representing an angle in radians</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Cos(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Cos(VBDoubleValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.4 Exp</strong>
@@ -54,7 +53,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>) representing the <em>power</em> to raise <c>e</c> by.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Exp(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Exp(VBDoubleValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.5 Log</strong>
@@ -64,7 +63,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>) <em>greater than zero</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Log(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Log(VBDoubleValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.6 Rnd</strong>
@@ -84,7 +83,7 @@ public interface IStdMathModule
     /// </list>
     /// </param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Rnd(VBRuntimeVariantValue Number);
+    RuntimeSemanticsEvaluationResult StdMath__Rnd(VBVariantValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.7 Round</strong>
@@ -95,7 +94,7 @@ public interface IStdMathModule
     /// <param name="Number">Any <see cref="VBVariantValue"/> containing the numeric value to be rounded.</param>
     /// <param name="NumDigitsAfterDecimal">Any <see cref="VBLongValue"/> containing representing the <em>number of decimal places</em> to the <em>right</em> of the <em>decimal separator</em> are included in the rounded result.<br/><strong>Optional</strong>: <see cref="VBLongType.DefaultValue"/> if omitted.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Round(VBRuntimeVariantValue Number, VBRuntimeValue<Int32> NumDigitsAfterDecimal);
+    RuntimeSemanticsEvaluationResult StdMath__Round(VBVariantValue Number, VBLongValue NumDigitsAfterDecimal);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.8 Sgn</strong>
@@ -110,7 +109,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>).</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Sgn(VBRuntimeVariantValue Number);
+    RuntimeSemanticsEvaluationResult StdMath__Sgn(VBVariantValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.9 Sin</strong>
@@ -120,7 +119,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>) <em>representing an angle in radians</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Sin(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Sin(VBDoubleValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.10 Sqr</strong>
@@ -130,7 +129,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>) <em>greater than</em> <c>0</c>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Sqr(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Sqr(VBDoubleValue Number);
 
     /// <summary>
     /// <strong>MS-VBAL 6.1.2.10.11 Tan</strong>
@@ -140,7 +139,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">Any <see cref="VBDoubleValue"/> containing a valid numeric value (i.e. not <c>NaN</c>) <em>representing an angle in radians</em>.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Tan(VBRuntimeValue<Double> Number);
+    RuntimeSemanticsEvaluationResult StdMath__Tan(VBDoubleValue Number);
 
     #endregion
 
@@ -154,7 +153,7 @@ public interface IStdMathModule
     /// </remarks>
     /// <param name="Number">A <see cref="VBNumericTypedValue"/> representing a <em>seed value</em>.<br/><strong>Optional</strong>: <see cref="VBMissingValue"/> or <see cref="VBEmptyValue"/> yields a new <em>seed value</em> from the <em>host-provided</em> pseudo-random number generator.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult StdMath__Randomize(VBRuntimeVariantValue Number);
+    RuntimeSemanticsEvaluationResult StdMath__Randomize(VBVariantValue Number);
 
     #endregion
 }

--- a/RDCore.SDK/Runtime/Abstract/StdLib/IStdRegExpClass.cs
+++ b/RDCore.SDK/Runtime/Abstract/StdLib/IStdRegExpClass.cs
@@ -1,5 +1,4 @@
 ﻿using RDCore.SDK.Model.Values.Intrinsic;
-using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Runtime.Abstract.StdLib;
@@ -22,7 +21,7 @@ public interface IStdRegExpClass
     /// Sets a flag indicating whether the regex returns after the first match (<c>false</c>) or not (<c>true</c>).
     /// </summary>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult IStdRegExpClass__setGlobal(VBRuntimeBooleanValue value);
+    RuntimeSemanticsEvaluationResult IStdRegExpClass__setGlobal(VBBooleanValue value);
 
     /// <summary>
     /// Gets or sets a flag indicating whether the regex evaluates case-insensitive (<c>true</c>) or case-sensitive (<c>false</c>) matches.
@@ -33,7 +32,7 @@ public interface IStdRegExpClass
     /// Sets a flag indicating whether the regex evaluates case-insensitive (<c>true</c>) or case-sensitive (<c>false</c>) matches.
     /// </summary>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult IStdRegExpClass__setIgnoreCase(VBRuntimeBooleanValue value);
+    RuntimeSemanticsEvaluationResult IStdRegExpClass__setIgnoreCase(VBBooleanValue value);
 
     /// <summary>
     /// Gets a flag indicating whether <c>^</c> and <c>$</c> denote the start/end of the <em>input</em> (<c>false</c>) or of a <em>single line</em> (<c>true</c>) of it.
@@ -42,7 +41,7 @@ public interface IStdRegExpClass
     /// <summary>
     /// Sets a flag indicating whether <c>^</c> and <c>$</c> denote the start/end of the <em>input</em> (<c>false</c>) or of a <em>single line</em> (<c>true</c>) of it.
     /// </summary>
-    RuntimeSemanticsEvaluationResult IStdRegExpClass__setMultiline(VBRuntimeBooleanValue value);
+    RuntimeSemanticsEvaluationResult IStdRegExpClass__setMultiline(VBBooleanValue value);
 
     /// <summary>
     /// Gets the Regular Expression pattern string for this instance.
@@ -51,7 +50,7 @@ public interface IStdRegExpClass
     /// <summary>
     /// Sets the Regular Expression pattern string for this instance.
     /// </summary>
-    RuntimeSemanticsEvaluationResult IStdRegExpClass__setPattern(VBRuntimeReference value);
+    RuntimeSemanticsEvaluationResult IStdRegExpClass__setPattern(VBStringValue value);
     #endregion
 
     #region Public Methods
@@ -60,20 +59,20 @@ public interface IStdRegExpClass
     /// </summary>
     /// <param name="sourceString">The input string to match against the configured pattern.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult Execute(VBRuntimeReference sourceString);
+    RuntimeSemanticsEvaluationResult Execute(VBStringValue sourceString);
     /// <summary>
     /// Replaces regex matches in the provided <em>source string</em> with the specified <em>replacement value</em>.
     /// </summary>
     /// <param name="sourceString">The input string to replace matched content from.</param>
     /// <param name="replaceVar">The replacement value for any pattern matches.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult Replace(VBRuntimeReference sourceString, VBRuntimeVariantValue replaceVar);
+    RuntimeSemanticsEvaluationResult Replace(VBStringValue sourceString, VBVariantValue replaceVar);
     /// <summary>
     /// Tests whether the specified <em>source string</em> matches the currently configured <c>Pattern</c> for this instance.
     /// </summary>
     /// <param name="sourceString">The input string to test against the configured pattern.</param>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult Test(VBRuntimeReference sourceString);
+    RuntimeSemanticsEvaluationResult Test(VBStringValue sourceString);
     #endregion
 }
 
@@ -132,7 +131,7 @@ public interface IStdMatchCollectionClass
     /// 👉 This property is exposed as the <em>default member</em> of this class type.
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult IStdMatchCollectionClass__getItem(VBRuntimeValue<Int32> index);
+    RuntimeSemanticsEvaluationResult IStdMatchCollectionClass__getItem(VBLongValue index);
     #endregion
 }
 
@@ -156,6 +155,6 @@ public interface IStdSubMatchesClass
     /// 👉 This property is exposed as the <em>default member</em> of this class type.
     /// </remarks>
     /// <returns>A <see cref="RuntimeSemanticsEvaluationResult"/> object encapsulating the result of the successful operation, or the error metadata otherwise.</returns>
-    RuntimeSemanticsEvaluationResult IStdSubMatchesClass__getItem(VBRuntimeValue<Int32> index);
+    RuntimeSemanticsEvaluationResult IStdSubMatchesClass__getItem(VBLongValue index);
     #endregion
 }


### PR DESCRIPTION
#90 changed the RDCore.SDK.Runtime.Abstract.StdLib interfaces from the semantic value model (VBVariantValue, VBDoubleValue, VBLongValue, ...) to the runtime layer (VBRuntimeVariantValue, VBRuntimeValue<T>, ...). Nothing implements these interfaces yet, and a standard-library symbol provider wants the semantic signatures (VBType-resolvable) rather than the runtime structs. Restores the 8 touched files to their pre-#90 state; build + tests unchanged.