### PR TITLE
Parse robustness pass

### DIFF
--- a/RDCore.CLI/Host/Handlers/DefineSymbolsHandler.cs
+++ b/RDCore.CLI/Host/Handlers/DefineSymbolsHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.JsonRpc;
 using RDCore.CLI.Host;
+using RDCore.SDK.Model.Symbols.Abstract;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Platform.Protocol;
@@ -42,9 +43,19 @@ internal sealed class DefineSymbolsHandler(
         }
 
         var defined = 0;
+        var merged = 0;
         var skipped = new List<string>();
-        foreach (var symbol in SymbolDescriptorReader.Read(request, ResolveType))
+
+        // the language server already collapses #If-branch duplicates, but stay defensive: fuse any
+        // that still arrive with the same identity (uri + concrete type) so the session never sees a
+        // colliding define. Property Get/Let/Set share a uri but not a type, so they stay distinct.
+        foreach (var group in SymbolDescriptorReader.Read(request, ResolveType)
+            .GroupBy(symbol => (symbol.Uri.ToString(), symbol.GetType())))
         {
+            var sites = group.ToList();
+            merged += sites.Count - 1;
+            var symbol = sites.Find(candidate => candidate is BoundSymbol { Definitions.IsDefaultOrEmpty: false }) ?? sites[0];
+
             if (session.Symbols.TryDefine(symbol, symbol.ScopeKind))
             {
                 defined++;
@@ -58,8 +69,8 @@ internal sealed class DefineSymbolsHandler(
         if (logger.IsEnabled(LogLevel.Information))
         {
             logger.LogInformation(
-                "📥 {module}: defined {defined} symbol(s), skipped {skipped}, {unresolved} unresolved type name(s).",
-                request.ModuleName, defined, skipped.Count, unresolvedTypeNames.Count);
+                "📥 {module}: defined {defined} symbol(s), merged {merged}, skipped {skipped}, {unresolved} unresolved type name(s).",
+                request.ModuleName, defined, merged, skipped.Count, unresolvedTypeNames.Count);
         }
 
         return Task.FromResult(new DefineSymbolsResult
@@ -67,6 +78,7 @@ internal sealed class DefineSymbolsHandler(
             Defined = defined,
             Skipped = skipped,
             UnresolvedTypeNames = [.. unresolvedTypeNames],
+            MergedDefinitions = merged,
         });
     }
 }

--- a/RDCore.LanguageServer/Parsing/ParsingClientService.cs
+++ b/RDCore.LanguageServer/Parsing/ParsingClientService.cs
@@ -64,6 +64,13 @@ internal sealed class ParsingClientService(
             logger.LogInformation("📄 Parsed {uri}: {status}", documentUri,
                 result.IsSuccess ? "ok" : $"{result.SyntaxErrors.Length} syntax error(s)");
         }
+        if (!result.IsSuccess && logger.IsEnabled(LogLevel.Warning))
+        {
+            foreach (var error in result.SyntaxErrors)
+            {
+                logger.LogWarning("   ↳ {detail}", error.Verbose);
+            }
+        }
         return result;
     }
 
@@ -73,13 +80,30 @@ internal sealed class ParsingClientService(
         {
             await orchestration.ParsingService.WaitForReadyAsync(token);
 
+            var parsed = 0;
+            var failed = 0;
             foreach (var document in documents.GetAllDocuments())
             {
                 token.ThrowIfCancellationRequested();
-                await ParseDocumentAsync(document.Id.Uri.ToUri(), ModuleTypeOf(document), token);
+                var uri = document.Id.Uri.ToUri();
+                try
+                {
+                    await ParseDocumentAsync(uri, ModuleTypeOf(document), token);
+                    parsed++;
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    // a parser failure on one module must not abort the whole workspace parse.
+                    failed++;
+                    logger.LogError(exception, "❌ Parse failed for {uri}.", uri);
+                }
             }
 
-            LogIfEnabled(LogLevel.Information, "✅ Workspace parse completed");
+            LogIfEnabled(LogLevel.Information, $"✅ Workspace parse completed ({parsed} ok, {failed} failed)");
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {

--- a/RDCore.LanguageServer/Symbols/SymbolDescriptorProjector.cs
+++ b/RDCore.LanguageServer/Symbols/SymbolDescriptorProjector.cs
@@ -50,11 +50,24 @@ internal static class SymbolDescriptorProjector
             DeclaredTypeName = DeclaredTypeNameOf(accessible),
             Range = accessible?.Range ?? default,
             SelectionRange = accessible?.SelectionRange ?? default,
+            Definitions = DefinitionsOf(symbol),
             Parameters = ParametersOf(symbol),
             Members = [.. children.Select(child => Describe(child, KindOf(child), []))],
             External = ExternalOf(symbol),
         };
     }
+
+    // carried only for a multi-branch symbol; the common single-declaration descriptor stays lean and
+    // consumers read Range/SelectionRange.
+    private static ImmutableArray<DefinitionDescriptor> DefinitionsOf(Symbol symbol)
+        => symbol is BoundSymbol { Definitions.IsDefaultOrEmpty: false } bound
+            ? [.. bound.Definitions.Select(definition => new DefinitionDescriptor
+            {
+                Range = definition.Range,
+                SelectionRange = definition.SelectionRange,
+                State = definition.State,
+            })]
+            : [];
 
     private static SymbolDescriptorKind KindOf(Symbol symbol) => symbol switch
     {

--- a/RDCore.LanguageServer/Symbols/SyntaxTreeSymbolProvider.cs
+++ b/RDCore.LanguageServer/Symbols/SyntaxTreeSymbolProvider.cs
@@ -6,9 +6,11 @@ using RDCore.SDK.Runtime.Abstract.Execution;
 namespace RDCore.LanguageServer.Symbols;
 
 /// <summary>
-/// Produces the member symbols a module declares, resolved from its parsed declaration AST. Both live
-/// and dead conditional-compilation branches are present in the tree, so both are yielded — the
-/// language server keeps or drops each one once it knows the live <c>#Const</c> values.
+/// Produces the member symbols a module declares, resolved from its parsed declaration AST. The tree
+/// carries every conditional-compilation branch, so a name declared in more than one branch
+/// (<c>#If VBA7 Then … #Else … #End If</c>) is collapsed into a single symbol whose
+/// <see cref="BoundSymbol.Definitions"/> lists each branch's declaration site; a later pass marks
+/// the sites live or dead from the resolved <c>#Const</c> values.
 /// </summary>
 /// <remarks>
 /// The containing module symbol is the project symbol provider's responsibility; library reference
@@ -19,6 +21,43 @@ internal sealed class SyntaxTreeSymbolProvider(
     Uri workspaceRoot, Uri moduleUri, ModuleParseResult parseResult, ISymbolResolver resolver) : ISymbolProvider
 {
     public IEnumerable<Symbol> ProvideSymbols()
+    {
+        // one identity (same uri, same concrete symbol type) can be declared once per #If branch —
+        // uri alone would also fuse Property Get/Let/Set, which must stay distinct. collapse each
+        // such group into the first site, carrying every site in Definitions.
+        // FIXME Property Get/Let/Set of one name share a Symbol.Uri (Symbol.CreateUri keys on name
+        // only); the concrete-type part of this key is what keeps them apart here, and _idMap in the
+        // session is still last-wins across them. give accessors a distinct semantic id (e.g. a
+        // "/get" | "/let" | "/set" uri suffix) — deferred, it's an identity change across the symbol
+        // ctors, SymbolDescriptorReader.ChildUri and every by-name uri lookup.
+        foreach (var group in EnumerateDeclaredSymbols().GroupBy(symbol => (symbol.Uri.ToString(), symbol.GetType())))
+        {
+            var sites = group.ToList();
+            if (sites.Count == 1)
+            {
+                yield return sites[0];
+                continue;
+            }
+
+            var bound = sites.OfType<BoundSymbol>().OrderBy(symbol => symbol.Range).ToList();
+            if (bound.Count != sites.Count)
+            {
+                // unbound duplicates aren't expected from the ast — pass them through untouched.
+                foreach (var site in sites)
+                {
+                    yield return site;
+                }
+                continue;
+            }
+
+            yield return bound[0] with
+            {
+                Definitions = [.. bound.Select(symbol => new SymbolDefinition(symbol.Range, symbol.SelectionRange, DefinitionState.Unknown))],
+            };
+        }
+    }
+
+    private IEnumerable<Symbol> EnumerateDeclaredSymbols()
     {
         if (parseResult.SyntaxTree is not { } module)
         {

--- a/RDCore.Parsing/AST/DeclarationNodeBuilder.cs
+++ b/RDCore.Parsing/AST/DeclarationNodeBuilder.cs
@@ -11,16 +11,16 @@ internal class DeclarationNodeBuilder(Uri rootUri, SyntaxNodeId nodeId) : NodeBu
 { 
     public SyntaxNode BuildAttributeDirective(VBAParser.AttributeStmtContext context)
     {
-        // name may be qualified
+        // the name may be member-qualified (`Attribute Foo.VB_Description = …`).
         var identifiers = context.attributeName().GetText().Split('.');
         var name = identifiers.Length == 1 ? identifiers[0] : identifiers.Last();
         var qualifier = identifiers.Length == 2 ? identifiers[0] : null;
-        return new AttributeDirectiveNode(
-            NodeId,
-            context.GetSourceLocation(_rootUri),
-            name,
-            _children[0],
-            qualifier);
+
+        // read the value straight from the parse tree — the declarations pass does not collect a
+        // procedure body's expressions, so a member-level attribute has no child value node.
+        var value = string.Join(", ", context.attributeValue().Select(node => node.GetText()));
+
+        return new AttributeDirectiveNode(NodeId, context.GetSourceLocation(_rootUri), name, value, qualifier);
     }
     public SyntaxNode BuildImplementsDirective(VBAParser.ImplementsStmtContext context) =>
         new ImplementsDirectiveNode(

--- a/RDCore.Parsing/AST/DeclarationsParseTreeListener.cs
+++ b/RDCore.Parsing/AST/DeclarationsParseTreeListener.cs
@@ -35,7 +35,12 @@ internal class DeclarationsParseTreeListener(Uri sourceUri, ModuleNode moduleNod
 
     public ModuleNode BuildModuleNode()
     {
-        Debug.Assert(_builderStack.Count == 1);
+        // ANTLR error recovery can leave scopes open (an Enter with no matching Exit); unwind to the
+        // module builder so a module with syntax errors still yields whatever declarations parsed.
+        while (_builderStack.Count > 1)
+        {
+            _builderStack.Pop();
+        }
         return _root with { Children = [.. CurrentBuilder.GetChildren] };
     }
 
@@ -46,6 +51,11 @@ internal class DeclarationsParseTreeListener(Uri sourceUri, ModuleNode moduleNod
 
     private void OnExitParent(Func<DeclarationNodeBuilder, SyntaxNode> provider)
     {
+        // error recovery can fire an Exit with no matching Enter — never pop the module builder.
+        if (_builderStack.Count <= 1)
+        {
+            return;
+        }
         var node = provider.Invoke(_builderStack.Pop());
         CurrentBuilder.AddChild(node);
     }

--- a/RDCore.Parsing/Handlers/ParseFullDocumentHandler.cs
+++ b/RDCore.Parsing/Handlers/ParseFullDocumentHandler.cs
@@ -3,6 +3,7 @@ using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Server;
 using RDCore.SDK.Client;
 using RDCore.SDK.Model.AST;
+using RDCore.SDK.Model.Source;
 using RDCore.SDK.Platform.Protocol;
 using System.IO.Abstractions;
 
@@ -36,8 +37,10 @@ public class ParseFullDocumentHandler(IFile fileService, IModuleParser modulePar
         }
         catch (Exception exception)
         {
+            // a parser or serialization failure on one module degrades to a failed result carrying the
+            // detail, rather than a bare JSON-RPC "-32603 Internal error" the caller can't act on.
             logger.LogError(exception, "❌ {method} failed for {uri}", RDCorePlatformProtocol.ParseFullDocument, uri);
-            throw;
+            return PlatformJsonEnvelope.Of(ModuleParseResult.Failed(new SourceLocation(uri, SourceRange.Empty), exception.ToString()));
         }
     }
 }

--- a/RDCore.Parsing/ModuleParser.cs
+++ b/RDCore.Parsing/ModuleParser.cs
@@ -37,11 +37,10 @@ internal partial class ModuleParser() : IModuleParser
         var precompilerTrivia = ParsePrecompilerNodes(content, errorListener, [directiveListener]);
 
         var node = new ModuleNode(new SyntaxNodeId(uri.AbsolutePath, []), new(uri, SourceRange.Empty), precompilerTrivia, moduleType);
-        var listener = new DeclarationsParseTreeListener(uri, node);
         try
         {
             var sanitized = PrecompilerNodePattern().Replace(content, match => new string(' ', match.Length));
-            ParseWithFallback(sanitized, errorListener, [listener]);
+            var listener = ParseWithFallback(sanitized, errorListener, () => new DeclarationsParseTreeListener(uri, node));
 
             var ast = listener.BuildModuleNode();
             return ast.Children.Length > 0 
@@ -73,46 +72,57 @@ internal partial class ModuleParser() : IModuleParser
         {
             parser.AddParseListener(listener);
         }
-        parser.compilationUnit();
+
+        try
+        {
+            parser.compilationUnit();
+        }
+        catch (Exception)
+        {
+            // the conditional-compilation pass is best-effort: default error recovery can fire
+            // unbalanced enter/exit events into a stateful listener. A failure here forfeits the
+            // precompiler trivia for this module, not the module.
+        }
         return [.. listeners.SelectMany(provider => provider.SyntaxNodes)];
     }
 
-    private static void ParseWithFallback(string content, ErrorListener errorListener, IParseTreeListener[] listeners)
+    /// <summary>
+    /// Two-stage parse: SLL with a bail-on-first-error strategy (fast, and it never runs default error
+    /// recovery — which would desynchronize a stateful parse listener), then LL with default recovery
+    /// on a <em>fresh</em> listener if SLL bailed.
+    /// </summary>
+    private static TListener ParseWithFallback<TListener>(string content, ErrorListener errorListener, Func<TListener> listenerFactory)
+        where TListener : IParseTreeListener
+    {
+        try
+        {
+            return ParseOnce(content, PredictionMode.Sll, new BailErrorStrategy(), errorListener: null, listenerFactory());
+        }
+        catch (Exception exception) when (exception is ParseCanceledException or RecognitionException)
+        {
+            return ParseOnce(content, PredictionMode.Ll, new DefaultErrorStrategy(), errorListener, listenerFactory());
+        }
+    }
+
+    private static TListener ParseOnce<TListener>(string content, PredictionMode mode, IAntlrErrorStrategy errorStrategy, ErrorListener? errorListener, TListener listener)
+        where TListener : IParseTreeListener
     {
         var stream = new AntlrInputStream(content);
         var lexer = new VBALexer(stream);
         var tokens = new CommonTokenStream(lexer);
-
-        try
+        var parser = new VBAParser(tokens)
         {
-            ParseFast(tokens, errorListener, listeners);
-        }
-        catch (InputMismatchException)
-        {
-            ParseSlow(tokens, errorListener, listeners);
-        }
-        catch (RecognitionException)
-        {
-            ParseSlow(tokens, errorListener, listeners);
-        }
-    }
-
-    private static void ParseFast(CommonTokenStream tokenStream, ErrorListener errorListener, IParseTreeListener[] listeners) 
-        => Parse(tokenStream, PredictionMode.Sll, errorListener, listeners);
-
-    private static void ParseSlow(CommonTokenStream tokenStream, ErrorListener errorListener, IParseTreeListener[] listeners) 
-        => Parse(tokenStream, PredictionMode.Ll, errorListener, listeners);
-
-    private static void Parse(CommonTokenStream tokenStream, PredictionMode mode, ErrorListener errorListener, IParseTreeListener[] listeners)
-    {
-        var parser = new VBAParser(tokenStream);
+            ErrorHandler = errorStrategy,
+        };
         parser.Interpreter.PredictionMode = mode;
-        parser.AddErrorListener(errorListener);
-        foreach (var listener in listeners)
+        parser.RemoveErrorListeners();
+        if (errorListener is not null)
         {
-            parser.AddParseListener(listener);
+            parser.AddErrorListener(errorListener);
         }
+        parser.AddParseListener(listener);
         parser.startRule();
+        return listener;
     }
 
     [GeneratedRegex(@"^[ \t]*#.*$", RegexOptions.Multiline)]

--- a/RDCore.Parsing/PrecompilerDirectiveListener.cs
+++ b/RDCore.Parsing/PrecompilerDirectiveListener.cs
@@ -47,13 +47,22 @@ internal class PrecompilerDirectiveListener(Uri sourceUri) : VBAConditionalCompi
 
     public ImmutableArray<SyntaxNode> BuildModuleNode()
     {
-        Debug.Assert(_builderStack.Count == 1);
+        // error recovery may leave scopes open — unwind to the root builder.
+        while (_builderStack.Count > 1)
+        {
+            _builderStack.Pop();
+        }
         return [.. CurrentBuilder.GetChildren];
     }
 
     private void OnEnterParent() => _builderStack.Push(new(_rootUri, GetCurrentNodeId()));
     private void OnExitParent(Func<PrecompilerNodeBuilder, SyntaxNode> provider)
     {
+        // an Exit with no matching Enter (error recovery) must not pop the root builder.
+        if (_builderStack.Count <= 1)
+        {
+            return;
+        }
         var node = provider.Invoke(_builderStack.Pop());
         CurrentBuilder.AddChild(node);
     }

--- a/RDCore.Parsing/Program.cs
+++ b/RDCore.Parsing/Program.cs
@@ -95,6 +95,12 @@ public class RDCoreParserApp(
         services.AddSingleton<IFileSystem, FileSystem>();
         services.AddSingleton(provider => provider.GetRequiredService<IFileSystem>().File);
         services.AddSingleton<IModuleParser, ModuleParser>();
+
+        // handlers resolve ILogger<T> from the OmniSharp-internal container, which otherwise has no
+        // sink — route it to the same RDCore.ParseServer.log the outer host writes.
+        services.AddLogging(builder => builder.AddFile(
+            System.IO.Path.Combine(RDCore.SDK.Platform.PlatformEnvironment.Default.LogsDirectory, "RDCore.ParseServer.log"),
+            LogLevel.Debug));
     }
 
     protected override void Dispose(bool disposing)

--- a/RDCore.SDK/Model/AST/Abstract/SyntaxNode.cs
+++ b/RDCore.SDK/Model/AST/Abstract/SyntaxNode.cs
@@ -83,7 +83,8 @@ public abstract record class SyntaxNode(SyntaxNodeId Identity, SourceLocation So
     /// </summary>
     public SourceLocation SourceLocation { get; init; } = SourceLocation;
     /// <summary>
-    /// The child syntax nodes.
+    /// The child syntax nodes. A <c>default</c> array is normalized to empty so it always
+    /// enumerates (and serializes) safely.
     /// </summary>
-    public ImmutableArray<SyntaxNode> Children { get; init; } = Children;
+    public ImmutableArray<SyntaxNode> Children { get; init; } = Children.IsDefault ? [] : Children;
 }

--- a/RDCore.SDK/Model/AST/Declarations/MemberDeclarationNode.cs
+++ b/RDCore.SDK/Model/AST/Declarations/MemberDeclarationNode.cs
@@ -14,10 +14,7 @@ namespace RDCore.SDK.Model.AST.Declarations;
 /// <param name="MemberKind">Specifies the kind of member.</param>
 /// <param name="AccessModifier">An access modifier, if one was supplied.</param>
 public record class MemberDeclarationNode(SyntaxNodeId Identity, SourceLocation SourceLocation, ImmutableArray<SyntaxNode> Children, string Name, MemberKind MemberKind, AccessModifier AccessModifier = AccessModifier.Implicit)
-    : SyntaxNode(Identity, SourceLocation, Children)
-{
-    ExpressionNode? DeclaredTypeExpression => Children.OfType<ExpressionNode>().SingleOrDefault();
-};
+    : SyntaxNode(Identity, SourceLocation, Children);
 /// <summary>
 /// 
 /// </summary>

--- a/RDCore.SDK/Model/AST/Directives/ModuleDirectives.cs
+++ b/RDCore.SDK/Model/AST/Directives/ModuleDirectives.cs
@@ -62,11 +62,12 @@ public record class TypeDefDirectiveNode(SyntaxNodeId Identity, SourceLocation L
 /// </summary>
 /// <param name="Identity">A unique identifier for this specific syntax node.</param>
 /// <param name="Location">The <c>Location</c> of the directive.</param>
-public record class ImplementsDirectiveNode(SyntaxNodeId Identity, SourceLocation Location, ExpressionNode? NameExpression = null)
+public record class ImplementsDirectiveNode(SyntaxNodeId Identity, SourceLocation Location, SyntaxNode? NameExpression = null)
     : DirectiveNode(Identity, Location, NameExpression is null ? [] : [NameExpression])
 {
     /// <summary>
-    /// Gets an expression resolving the identifier name of the implemented interface.
+    /// The name expression resolving the implemented interface — the directive's single child.
     /// </summary>
-    public ExpressionNode NameExpression => Children.OfType<ExpressionNode>().Single();
+    [JsonIgnore]
+    public SyntaxNode NameExpression => Children.Single();
 }

--- a/RDCore.SDK/Model/AST/Directives/ModuleDirectives.cs
+++ b/RDCore.SDK/Model/AST/Directives/ModuleDirectives.cs
@@ -8,15 +8,15 @@ using System.Text.Json.Serialization;
 namespace RDCore.SDK.Model.AST.Directives;
 
 /// <summary>
-/// A <c>BoundNode</c> representing a <c>VB_Attribute</c> directive.
+/// A <c>BoundNode</c> representing a <c>VB_Attribute</c> directive (module- or member-level).
 /// </summary>
 /// <param name="Identity">A unique identifier for this specific syntax node.</param>
 /// <param name="Location">The <c>Location</c> of the directive.</param>
-/// <param name="Name">The name of the attribute.</param>
-/// <param name="ValueExpression">An expression node that statically evaluates to the value of the attribute.</param>
-/// <param name="Binding">An optional qualifier used for binding the attribute to the member it belongs to.</param>
-public record class AttributeDirectiveNode(SyntaxNodeId Identity, SourceLocation Location, string Name, SyntaxNode ValueExpression, string? Binding = null)
-    : DirectiveNode(Identity, Location, [ValueExpression]);
+/// <param name="Name">The unqualified name of the attribute (e.g. <c>VB_Description</c>, <c>VB_UserMemId</c>).</param>
+/// <param name="Value">The raw source text of the attribute value(s) — e.g. <c>"…"</c>, <c>0</c>, <c>True</c>. Comma-separated values are joined with <c>", "</c>.</param>
+/// <param name="Binding">The member-name qualifier for a member-level attribute (<c>Foo</c> in <c>Attribute Foo.VB_Description</c>); <c>null</c> for a module-level attribute.</param>
+public record class AttributeDirectiveNode(SyntaxNodeId Identity, SourceLocation Location, string Name, string Value, string? Binding = null)
+    : DirectiveNode(Identity, Location, []);
 
 /// <summary>
 /// A <c>BoundNode</c> representing an <c>Option</c> module directive.

--- a/RDCore.SDK/Model/AST/Expressions/VBBinaryOperatorExpressionNode.cs
+++ b/RDCore.SDK/Model/AST/Expressions/VBBinaryOperatorExpressionNode.cs
@@ -3,6 +3,7 @@ using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Symbols.Abstract;
 using RDCore.SDK.Model.Values.Abstract;
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 namespace RDCore.SDK.Model.AST.Expressions;
 
 /// <summary>
@@ -28,6 +29,12 @@ public record class VBBinaryOperatorExpressionNode : VBOperatorExpression
     }
 
     public string Token { get; }
+
+    /// <summary>The left operand — <c>Children[0]</c>, reconstructed from <c>Children</c> on deserialization.</summary>
+    [JsonIgnore]
     public ExpressionNode Left { get; }
+
+    /// <summary>The right operand — <c>Children[1]</c>, reconstructed from <c>Children</c> on deserialization.</summary>
+    [JsonIgnore]
     public ExpressionNode Right { get; }
 }

--- a/RDCore.SDK/Model/AST/ModuleParseResult.cs
+++ b/RDCore.SDK/Model/AST/ModuleParseResult.cs
@@ -15,7 +15,7 @@ public record class ModuleParseResult
     };
 
     public ModuleNode? SyntaxTree { get; init; }
-    public ImmutableArray<SyntaxNode> PrecompilerTrivia { get; init; }
+    public ImmutableArray<SyntaxNode> PrecompilerTrivia { get; init; } = [];
     public ImmutableArray<VBSyntaxErrorInfo> SyntaxErrors { get; init; } = [];
 
     public bool IsSuccess => SyntaxTree is not null && SyntaxErrors.Length == 0;

--- a/RDCore.SDK/Model/Errors/VBSyntaxErrorInfo.cs
+++ b/RDCore.SDK/Model/Errors/VBSyntaxErrorInfo.cs
@@ -8,35 +8,27 @@ namespace RDCore.SDK.Model.Errors;
 /// </summary>
 /// <remarks>
 /// A <em>syntax error</em> occurs while traversing the <em>concrete syntax tree</em> (CST) in the parser.
+/// A single positional constructor keeps the type round-trippable through <see cref="System.Text.Json"/>.
 /// </remarks>
-/// <param name="VBCompileErrorId">The formal <see cref="VBCompileErrorId"/> value for this specific syntax error.</param>
+/// <param name="ErrorId">The numeric representation of the <see cref="VBCompileErrorId"/> for this syntax error.</param>
 /// <param name="Location">The document location of the faulted CST node.</param>
-/// <param name="Description">An optional error description. "Syntax error" unless specified otherwise.</param>
+/// <param name="Description">An error description. "Syntax error" unless specified otherwise.</param>
 /// <param name="Verbose">A detailed message identifying the faulted CST token and detailing its semantics.</param>
-public record class VBSyntaxErrorInfo : VBErrorInfo
+public record class VBSyntaxErrorInfo(int ErrorId, SourceLocation Location, string Description, string Verbose)
+    : VBErrorInfo(ErrorId, Location, Description, Verbose)
 {
-    private VBSyntaxErrorInfo(VBCompileErrorId errorId, SourceLocation location, string description, string verbose)
-        : base((int)errorId, location, description, verbose) 
-    {
-        VBCompileErrorId = errorId;
-    }
+    /// <summary>
+    /// The formal error ID — a class of <em>compilation error</em> that occurs during parsing as the
+    /// syntax tree is assembled.
+    /// </summary>
+    public VBCompileErrorId VBCompileErrorId => (VBCompileErrorId)ErrorId;
 
     /// <summary>
-    /// The unique error ID for this <em>syntax error</em>.
+    /// Creates a <see cref="VBSyntaxErrorInfo"/> for the specified <see cref="VBCompileErrorId"/> at the specified <see cref="SourceLocation"/>.
     /// </summary>
-    /// <remarks>
-    /// 👉 <em>Syntax errors</em> are a class of <em>compilation errors</em> that occur during the <em>parsing</em> process, 
-    /// as the <em>abstract syntax tree</em> (AST) is being assembled.
-    /// </remarks>
-    public VBCompileErrorId VBCompileErrorId { get; }
-
-    /// <summary>
-    /// Creates a new <see cref="VBSyntaxErrorInfo"/> describing the specified <see cref="VBCompileErrorId"/> at the specified <see cref="SourceLocation"/>.
-    /// </summary>
-    /// <param name="vbCompileErrorId">The formal <see cref="VBCompileErrorId"/> value for this error.</param>
-    /// <param name="location">The document location of the problematic <em>node</em>.</param>
-    /// <param name="Verbose">A detailed message that is optionally appended, depending on the current <em>server trace</em> configuration.</param>
-    /// <returns>A new instance of a <see cref="VBSyntaxErrorInfo"/> encapsulating the specified error metadata with a localized description string.</returns>
-    public static VBSyntaxErrorInfo For(VBCompileErrorId vbCompileErrorId, SourceLocation location, string Verbose) 
-        => new(vbCompileErrorId, location, VBCompileErrorInfo.GetErrorString(vbCompileErrorId), Verbose);
+    /// <param name="vbCompileErrorId">The formal error code.</param>
+    /// <param name="location">The document location of the problematic node.</param>
+    /// <param name="Verbose">A detailed message appended depending on the server trace configuration.</param>
+    public static VBSyntaxErrorInfo For(VBCompileErrorId vbCompileErrorId, SourceLocation location, string Verbose)
+        => new((int)vbCompileErrorId, location, VBCompileErrorInfo.GetErrorString(vbCompileErrorId), Verbose);
 }

--- a/RDCore.SDK/Model/Symbols/Abstract/BoundSymbol.cs
+++ b/RDCore.SDK/Model/Symbols/Abstract/BoundSymbol.cs
@@ -1,4 +1,5 @@
 ﻿using RDCore.SDK.Model.Source;
+using System.Collections.Immutable;
 
 namespace RDCore.SDK.Model.Symbols.Abstract;
 
@@ -12,8 +13,43 @@ namespace RDCore.SDK.Model.Symbols.Abstract;
 /// <param name="Kind">A <c>SymbolKind</c> (extensible) metadata value describing the kind of symbol.</param>
 /// <param name="Range">The entire document <c>Range</c> belonging to this symbol.</param>
 /// <param name="SelectionRange">The specific document <c>Range</c> to highlight when this symbol is selected, usually the symbol's <em>identifier</em> name if applicable.</param>
-public abstract record class BoundSymbol(Uri WorkspaceRoot, Uri ParentUri, string Name, ScopeKind Scope, SymbolKindExt Kind, 
-    SourceRange Range, SourceRange SelectionRange) : Symbol(WorkspaceRoot, ParentUri, Name, Scope, Kind) { }
+public abstract record class BoundSymbol(Uri WorkspaceRoot, Uri ParentUri, string Name, ScopeKind Scope, SymbolKindExt Kind,
+    SourceRange Range, SourceRange SelectionRange) : Symbol(WorkspaceRoot, ParentUri, Name, Scope, Kind)
+{
+    /// <summary>
+    /// Every source site where this symbol is declared, in source order — populated only when the
+    /// same name is declared in more than one conditional-compilation branch. Empty for the common
+    /// single-declaration case, in which <see cref="BoundSymbol.Range"/> and
+    /// <see cref="BoundSymbol.SelectionRange"/> are the sole site.
+    /// </summary>
+    public ImmutableArray<SymbolDefinition> Definitions { get; init; } = [];
+
+    /// <summary>
+    /// Every declaration site of this symbol: <see cref="Definitions"/> when it is populated,
+    /// otherwise a single synthesized <see cref="DefinitionState.Live"/> site over
+    /// <see cref="BoundSymbol.Range"/>. Use this when a caller needs to treat single- and
+    /// multi-branch symbols uniformly.
+    /// </summary>
+    public IEnumerable<SymbolDefinition> AllDefinitions => Definitions.IsDefaultOrEmpty
+        ? [new SymbolDefinition(Range, SelectionRange, DefinitionState.Live)]
+        : Definitions;
+
+    /// <summary>
+    /// The primary declaration span — the first <see cref="DefinitionState.Live"/> site, else the
+    /// first site, else <see cref="BoundSymbol.Range"/>. LSP navigation targets the primary; when no
+    /// precompiler-evaluation pass has run yet this is simply the first branch.
+    /// </summary>
+    public SourceRange PrimaryRange => PrimaryDefinition?.Range ?? Range;
+
+    /// <summary>
+    /// The primary selection span, chosen the same way as <see cref="PrimaryRange"/>.
+    /// </summary>
+    public SourceRange PrimarySelectionRange => PrimaryDefinition?.SelectionRange ?? SelectionRange;
+
+    private SymbolDefinition? PrimaryDefinition => Definitions.IsDefaultOrEmpty
+        ? null
+        : Definitions.FirstOrDefault(definition => definition.State == DefinitionState.Live) ?? Definitions[0];
+}
 
 /// <summary>
 /// A <c>Symbol</c> that is <strong>not bound</strong> to a workspace document <c>Location</c>.

--- a/RDCore.SDK/Model/Symbols/Abstract/SymbolDefinition.cs
+++ b/RDCore.SDK/Model/Symbols/Abstract/SymbolDefinition.cs
@@ -1,0 +1,45 @@
+using RDCore.SDK.Model.Source;
+
+namespace RDCore.SDK.Model.Symbols.Abstract;
+
+/// <summary>
+/// The conditional-compilation state of a single <see cref="SymbolDefinition"/> — whether the
+/// <c>#If</c> branch the declaration site sits in is the one that compiles.
+/// </summary>
+public enum DefinitionState
+{
+    /// <summary>
+    /// The branch has not been evaluated. A later precompiler-evaluation pass resolves it to
+    /// <see cref="Live"/> or <see cref="Dead"/>; until then every site of a multi-branch symbol is
+    /// <see cref="Unknown"/>.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The branch compiles: this is a live declaration site.
+    /// </summary>
+    Live,
+
+    /// <summary>
+    /// The branch does not compile: this declaration site is dead code, but it is still tracked so a
+    /// rename or move affects it alongside the live site.
+    /// </summary>
+    Dead,
+}
+
+/// <summary>
+/// One source site where a <see cref="BoundSymbol"/> is declared. A symbol carries more than one only
+/// when the same name is declared in several conditional-compilation branches
+/// (<c>#If VBA7 Then … #Else … #End If</c>); collapsing the branches to a single symbol lets a
+/// rename or refactor see and rewrite every site — live or dead — instead of blanking the inactive
+/// branch and losing it.
+/// </summary>
+/// <param name="Range">The full source span of this declaration site.</param>
+/// <param name="SelectionRange">
+/// The span to select when navigating to this site — typically the identifier token.
+/// </param>
+/// <param name="State">
+/// Whether this site's conditional-compilation branch compiles. <see cref="DefinitionState.Unknown"/>
+/// until a precompiler-evaluation pass resolves it.
+/// </param>
+public sealed record class SymbolDefinition(SourceRange Range, SourceRange SelectionRange, DefinitionState State = DefinitionState.Unknown);

--- a/RDCore.SDK/Platform/Protocol/HostSymbolsDefine.cs
+++ b/RDCore.SDK/Platform/Protocol/HostSymbolsDefine.cs
@@ -18,8 +18,9 @@ namespace RDCore.SDK.Platform.Protocol;
 /// <remarks>
 /// Module symbols are <em>not</em> carried here — the host already has them from the <c>.rdproj</c>.
 /// The descriptors are the transport form of what the language server's <c>SyntaxTreeSymbolProvider</c>
-/// produces, so both live and dead conditional-compilation branches may be present; the host defines
-/// what it is given and leaves branch selection to a later pass.
+/// produces. A name declared in several conditional-compilation branches arrives as one descriptor
+/// carrying every branch in <see cref="SymbolDescriptor.Definitions"/>; the host defines the single
+/// symbol and leaves live/dead branch selection to a later pass.
 /// </remarks>
 [Method(RDCorePlatformProtocol.DefineSymbols, Direction.ClientToServer)]
 public record class DefineSymbolsParams : IRequest, IRequest<DefineSymbolsResult>
@@ -67,6 +68,13 @@ public record class DefineSymbolsResult
     /// defined, with <c>VBUnknownType</c>; a later resolver pass can bind them.
     /// </summary>
     public IReadOnlyList<string> UnresolvedTypeNames { get; init; } = [];
+
+    /// <summary>
+    /// The number of duplicate descriptors that were collapsed into an already-reconstructed symbol
+    /// rather than defined separately — a member declared in more than one conditional-compilation
+    /// branch reaches the session as one symbol with multiple <see cref="SymbolDescriptor.Definitions"/>.
+    /// </summary>
+    public int MergedDefinitions { get; init; }
 }
 
 /// <summary>
@@ -103,14 +111,25 @@ public record class SymbolDescriptor
     public string? DeclaredTypeName { get; init; }
 
     /// <summary>
-    /// The source span of the whole declaration.
+    /// The source span of the whole declaration — the primary site (the first branch) when the
+    /// member has multiple <see cref="Definitions"/>.
     /// </summary>
     public SourceRange Range { get; init; }
 
     /// <summary>
-    /// The source span to select when navigating to the symbol (typically its name token).
+    /// The source span to select when navigating to the symbol (typically its name token) — the
+    /// primary site when the member has multiple <see cref="Definitions"/>.
     /// </summary>
     public SourceRange SelectionRange { get; init; }
+
+    /// <summary>
+    /// The declaration sites of this member, in source order — populated only when the same name is
+    /// declared in more than one conditional-compilation branch. Empty for the common
+    /// single-declaration case, in which <see cref="Range"/>/<see cref="SelectionRange"/> are the
+    /// sole site. A consumer that does not support multi-branch symbols can ignore this and use
+    /// <see cref="Range"/>.
+    /// </summary>
+    public ImmutableArray<DefinitionDescriptor> Definitions { get; init; } = [];
 
     /// <summary>
     /// Parameters, for the procedure, function, property and event kinds.
@@ -128,6 +147,29 @@ public record class SymbolDescriptor
     /// <see cref="SymbolDescriptorKind.ExternalProcedure"/> or <see cref="SymbolDescriptorKind.ExternalFunction"/>.
     /// </summary>
     public ExternalDescriptor? External { get; init; }
+}
+
+/// <summary>
+/// A transport-friendly projection of one <c>SymbolDefinition</c> — a single declaration site of a
+/// member declared in more than one conditional-compilation branch.
+/// </summary>
+public record class DefinitionDescriptor
+{
+    /// <summary>
+    /// The full source span of this declaration site.
+    /// </summary>
+    public SourceRange Range { get; init; }
+
+    /// <summary>
+    /// The source span to select when navigating to this site (typically its name token).
+    /// </summary>
+    public SourceRange SelectionRange { get; init; }
+
+    /// <summary>
+    /// Whether this site's conditional-compilation branch compiles.
+    /// <see cref="DefinitionState.Unknown"/> until a precompiler-evaluation pass resolves it.
+    /// </summary>
+    public DefinitionState State { get; init; } = DefinitionState.Unknown;
 }
 
 /// <summary>

--- a/RDCore.SDK/Platform/Protocol/SymbolDescriptorReader.cs
+++ b/RDCore.SDK/Platform/Protocol/SymbolDescriptorReader.cs
@@ -40,11 +40,33 @@ public static class SymbolDescriptorReader
 
         foreach (var descriptor in request.Symbols)
         {
+            // the primary symbol is always yielded first, ahead of any nested members (enum
+            // constants, udt fields) that carry their own descriptors — so only the first carries
+            // the descriptor's multi-branch Definitions.
+            var isPrimary = true;
             foreach (var symbol in Read(descriptor, workspaceRoot, moduleUri, resolveType))
             {
-                yield return symbol;
+                yield return isPrimary ? WithDefinitions(symbol, descriptor) : symbol;
+                isPrimary = false;
             }
         }
+    }
+
+    // a member declared in more than one conditional-compilation branch arrives as one descriptor
+    // carrying every site; rebuild them onto the reconstructed symbol. Range/SelectionRange stay the
+    // primary site the ctor already set.
+    private static Symbol WithDefinitions(Symbol symbol, SymbolDescriptor descriptor)
+    {
+        if (descriptor.Definitions.Length <= 1 || symbol is not BoundSymbol bound)
+        {
+            return symbol;
+        }
+
+        return bound with
+        {
+            Definitions = [.. descriptor.Definitions.Select(definition =>
+                new SymbolDefinition(definition.Range, definition.SelectionRange, definition.State))],
+        };
     }
 
     private static IEnumerable<Symbol> Read(SymbolDescriptor node, Uri workspaceRoot, Uri parentUri, Func<string, VBType?> resolveType)

--- a/RDCore.Tests/Cli/DefineSymbolsHandlerTests.cs
+++ b/RDCore.Tests/Cli/DefineSymbolsHandlerTests.cs
@@ -74,6 +74,22 @@ public sealed class DefineSymbolsHandlerTests
     }
 
     [TestMethod]
+    public async Task DuplicateDescriptors_MergeIntoOneSymbol_AndAreCounted()
+    {
+        var handler = NewHandler();
+
+        // two descriptors for the same identity (a name declared in both #If branches) reach the
+        // session as a single define; the collapsed one is reported in MergedDefinitions.
+        var result = await handler.Handle(
+            Request(Field("Flags", "Long"), Field("Flags", "Double")),
+            CancellationToken.None);
+
+        Assert.AreEqual(1, result.Defined);
+        Assert.AreEqual(1, result.MergedDefinitions);
+        Assert.AreEqual(0, result.Skipped.Count);
+    }
+
+    [TestMethod]
     public async Task BeforeSessionComposed_IsANoOp()
     {
         var result = await NewHandler(compose: false).Handle(Request(Procedure("DoWork")), CancellationToken.None);

--- a/RDCore.Tests/LanguageServer/SymbolDescriptorProjectorTests.cs
+++ b/RDCore.Tests/LanguageServer/SymbolDescriptorProjectorTests.cs
@@ -2,6 +2,7 @@ using RDCore.LanguageServer.Symbols;
 using RDCore.Parsing;
 using RDCore.SDK.Model;
 using RDCore.SDK.Model.AST.Declarations;
+using RDCore.SDK.Model.Symbols.Abstract;
 using RDCore.SDK.Platform.Protocol;
 
 namespace RDCore.Tests.LanguageServer;
@@ -132,7 +133,7 @@ public sealed class SymbolDescriptorProjectorTests
     }
 
     [TestMethod]
-    public void ConditionalCompilation_ProjectsBothBranches()
+    public void ConditionalCompilation_ProjectsOneDescriptorCarryingEveryBranch()
     {
         var descriptors = Project("""
             #If DEBUG Then
@@ -142,6 +143,9 @@ public sealed class SymbolDescriptorProjectorTests
             #End If
             """);
 
-        Assert.AreEqual(2, descriptors.Count(d => d.Name == "Foo"));
+        var foo = descriptors.Single(d => d.Name == "Foo");
+        Assert.AreEqual(2, foo.Definitions.Length);
+        Assert.IsTrue(foo.Definitions.All(d => d.State == DefinitionState.Unknown));
+        Assert.AreEqual(foo.Range, foo.Definitions[0].Range);
     }
 }

--- a/RDCore.Tests/LanguageServer/SyntaxTreeSymbolProviderTests.cs
+++ b/RDCore.Tests/LanguageServer/SyntaxTreeSymbolProviderTests.cs
@@ -109,7 +109,7 @@ public sealed class SyntaxTreeSymbolProviderTests
     }
 
     [TestMethod]
-    public void ConditionalCompilation_YieldsBothLiveAndDeadBranches()
+    public void ConditionalCompilation_MergesDuplicateNameIntoOneSymbolWithDefinitions()
     {
         const string source = """
             #If DEBUG Then
@@ -122,8 +122,18 @@ public sealed class SyntaxTreeSymbolProviderTests
 
         var fields = Provide(source).OfType<VBModuleFieldVariableMemberSymbol>().ToArray();
 
-        Assert.HasCount(3, fields);
-        Assert.HasCount(2, fields.Where(f => f.Name == "Foo").ToArray());
+        // Foo is declared in both branches -> one symbol, two definition sites; Bar stays single.
+        Assert.HasCount(2, fields);
+
+        var foo = fields.Single(f => f.Name == "Foo");
+        Assert.HasCount(2, foo.Definitions);
+        Assert.IsTrue(foo.Definitions.All(d => d.State == DefinitionState.Unknown));
+        // sites are in source order: the #If branch is first, so it is the primary.
+        Assert.IsTrue(foo.Definitions[0].Range.CompareTo(foo.Definitions[1].Range) < 0);
+        Assert.AreEqual(foo.Range, foo.Definitions[0].Range);
+
+        var bar = fields.Single(f => f.Name == "Bar");
+        Assert.IsEmpty(bar.Definitions);
     }
 
     [TestMethod]

--- a/RDCore.Tests/Parser/DeclarationPassParserTests.cs
+++ b/RDCore.Tests/Parser/DeclarationPassParserTests.cs
@@ -28,6 +28,33 @@ public class DeclarationPassParserTests
     }
 
     [TestMethod]
+    public void SplitStatementConditional_ReportsLocatedSyntaxErrors()
+    {
+        // legal VBA, but a #If that splits a statement (here the function header) cannot be parsed by
+        // an ANTLR grammar — Rubberduck never supported it either. we don't try; we only make sure the
+        // failure survives the two-stage parse as syntax-error metadata a client can anchor a squiggle on.
+        const string content = """
+            #If VBA7 Then
+            Private Function GetPtr() As LongPtr
+            #Else
+            Private Function GetPtr() As Long
+            #End If
+                GetPtr = 0
+            End Function
+            """;
+        var uri = TestUri.TestModuleUri();
+
+        var result = new ModuleParser().Parse(uri, ModuleType.StdModule, content);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotEmpty(result.SyntaxErrors);
+        Assert.IsTrue(result.SyntaxErrors.All(error => error.Location.Uri == uri));
+        Assert.IsTrue(
+            result.SyntaxErrors.Any(error => error.Location.Range.Start.Line > 0),
+            "at least one syntax error should carry a real source location");
+    }
+
+    [TestMethod]
     public void PrecompilerTrivia_IsIncludedInResult()
     {
         const string content = """

--- a/RDCore.Tests/Platform/HostSymbolsDefineSerializationTests.cs
+++ b/RDCore.Tests/Platform/HostSymbolsDefineSerializationTests.cs
@@ -71,6 +71,22 @@ public sealed class HostSymbolsDefineSerializationTests
                 Range = new SourceRange(1, 0, 1, 30),
                 SelectionRange = new SourceRange(1, 14, 1, 22),
             },
+            new SymbolDescriptor
+            {
+                Name = "GethWndWorkbook",
+                Kind = SymbolDescriptorKind.ExternalFunction,
+                AccessModifier = AccessModifier.Private,
+                Scope = ScopeKind.External,
+                DeclaredTypeName = "Long",
+                Range = new SourceRange(20, 0, 20, 60),
+                SelectionRange = new SourceRange(20, 25, 20, 39),
+                External = new ExternalDescriptor { IsPtrSafe = true, Library = "user32" },
+                Definitions =
+                [
+                    new DefinitionDescriptor { Range = new SourceRange(20, 0, 20, 60), SelectionRange = new SourceRange(20, 25, 20, 39) },
+                    new DefinitionDescriptor { Range = new SourceRange(24, 0, 24, 55), SelectionRange = new SourceRange(24, 25, 24, 39), State = DefinitionState.Dead },
+                ],
+            },
         ],
     };
 
@@ -88,7 +104,15 @@ public sealed class HostSymbolsDefineSerializationTests
             "serialization is not stable across a round trip");
 
         Assert.AreEqual("Mod1", once.ModuleName);
-        Assert.AreEqual(4, once.Symbols.Length);
+        Assert.AreEqual(5, once.Symbols.Length);
+
+        var multiBranch = once.Symbols[4];
+        Assert.AreEqual("GethWndWorkbook", multiBranch.Name);
+        Assert.AreEqual(2, multiBranch.Definitions.Length);
+        Assert.AreEqual(DefinitionState.Unknown, multiBranch.Definitions[0].State);
+        Assert.AreEqual(DefinitionState.Dead, multiBranch.Definitions[1].State);
+        Assert.AreEqual(new SourceRange(24, 0, 24, 55), multiBranch.Definitions[1].Range);
+        Assert.IsTrue(once.Symbols[0].Definitions.IsDefaultOrEmpty, "a single-branch descriptor keeps Definitions empty");
 
         var add = once.Symbols[0];
         Assert.AreEqual(SymbolDescriptorKind.Function, add.Kind);
@@ -117,11 +141,13 @@ public sealed class HostSymbolsDefineSerializationTests
             Defined = 7,
             Skipped = ["Foo", "Bar"],
             UnresolvedTypeNames = ["Widget"],
+            MergedDefinitions = 2,
         };
 
         var result = JsonSerializer.Deserialize<DefineSymbolsResult>(JsonSerializer.Serialize(original, Options), Options)!;
 
         Assert.AreEqual(7, result.Defined);
+        Assert.AreEqual(2, result.MergedDefinitions);
         CollectionAssert.AreEqual(new[] { "Foo", "Bar" }, result.Skipped.ToArray());
         CollectionAssert.AreEqual(new[] { "Widget" }, result.UnresolvedTypeNames.ToArray());
     }

--- a/RDCore.Tests/Platform/SymbolDescriptorReaderTests.cs
+++ b/RDCore.Tests/Platform/SymbolDescriptorReaderTests.cs
@@ -1,4 +1,5 @@
 using RDCore.SDK.Model;
+using RDCore.SDK.Model.Source;
 using RDCore.SDK.Model.Symbols.Abstract;
 using RDCore.SDK.Model.Symbols.VBProject;
 using RDCore.SDK.Model.Types;
@@ -129,6 +130,43 @@ public sealed class SymbolDescriptorReaderTests
         Assert.AreEqual("kernel32", external.Lib);
         Assert.AreEqual("GetTickCount64", external.Alias);
         Assert.AreEqual(VBTypeNames.VBLong, external.ResolvedType.Name);
+    }
+
+    [TestMethod]
+    public void MultiBranchDescriptor_ReconstructsEveryDefinitionSite()
+    {
+        var field = (VBModuleFieldVariableMemberSymbol)Read(new SymbolDescriptor
+        {
+            Name = "Flags",
+            Kind = SymbolDescriptorKind.ModuleField,
+            DeclaredTypeName = "Long",
+            Range = new SourceRange(1, 0, 1, 15),
+            SelectionRange = new SourceRange(1, 4, 1, 9),
+            Definitions =
+            [
+                new DefinitionDescriptor { Range = new SourceRange(1, 0, 1, 15), SelectionRange = new SourceRange(1, 4, 1, 9) },
+                new DefinitionDescriptor { Range = new SourceRange(3, 0, 3, 17), SelectionRange = new SourceRange(3, 4, 3, 9) },
+            ],
+        }).Single();
+
+        Assert.AreEqual(2, field.Definitions.Length);
+        Assert.IsTrue(field.Definitions.All(d => d.State == DefinitionState.Unknown));
+        // Range/SelectionRange stay the primary (first) site.
+        Assert.AreEqual(new SourceRange(1, 0, 1, 15), field.Range);
+        Assert.AreEqual(new SourceRange(3, 0, 3, 17), field.Definitions[1].Range);
+    }
+
+    [TestMethod]
+    public void SingleBranchDescriptor_LeavesDefinitionsEmpty()
+    {
+        var field = (VBModuleFieldVariableMemberSymbol)Read(new SymbolDescriptor
+        {
+            Name = "Total",
+            Kind = SymbolDescriptorKind.ModuleField,
+            DeclaredTypeName = "Long",
+        }).Single();
+
+        Assert.IsTrue(field.Definitions.IsDefaultOrEmpty);
     }
 
     [TestMethod]


### PR DESCRIPTION
Stress-tested against the OOP Battleship code base; introduces multiple-definition symbols (first encountered is the primary, until a precompilation pass determines which ones are dead/alive).