### PR TITLE
Feat/rdc new and trace forwarding

### DIFF
--- a/RDCore.CLI/App/Commands/CommandNames.cs
+++ b/RDCore.CLI/App/Commands/CommandNames.cs
@@ -3,4 +3,5 @@
 internal static class CommandNames
 {
     public static (string Name, string Alias) DescribeExtensionCommand = ("describe-ext", "x");
+    public static (string Name, string Alias) NewWorkspaceCommand = ("new", "n");
 }

--- a/RDCore.CLI/App/Commands/NewWorkspaceCommand.cs
+++ b/RDCore.CLI/App/Commands/NewWorkspaceCommand.cs
@@ -1,0 +1,139 @@
+﻿using CommandLine;
+using RDCore.SDK.ConsoleIO;
+using RDCore.SDK.ConsoleIO.Model;
+using RDCore.SDK.Workspace;
+using System.IO.Abstractions;
+
+namespace RDCore.CLI.App.Commands;
+
+/// <summary>
+/// The parsed <c>new</c> verb arguments.
+/// </summary>
+internal sealed class NewWorkspaceOptions
+{
+    [Value(0, MetaName = "path", Required = true, HelpText = "The workspace directory to scaffold. Created if it does not exist.")]
+    public string Path { get; set; } = string.Empty;
+
+    [Option("name", HelpText = "The project name. Defaults to the directory name.")]
+    public string? Name { get; set; }
+
+    [Option("empty", HelpText = "Write an empty project instead of scanning the directory for source files.")]
+    public bool Empty { get; set; }
+
+    [Option("force", HelpText = "Overwrite an existing .rdproj.")]
+    public bool Force { get; set; }
+}
+
+/// <summary>
+/// Scaffolds a <c>.rdproj</c> workspace at the given path. By default it walks the directory and adds
+/// every VBA module file as a module and everything else as a project file.
+/// </summary>
+internal sealed class NewWorkspaceCommand(
+    IConsoleMessageWriter writer,
+    IFileSystem fileSystem,
+    IProjectFileWriter projectWriter) : ICliCommand
+{
+    // VB module file kinds; the rest of a workspace's files are OtherFiles. Could move to the SDK
+    // once another consumer needs it.
+    private static readonly HashSet<string> ModuleExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".bas", ".cls", ".frm", ".doccls",
+    };
+
+    public string Name => CommandNames.NewWorkspaceCommand.Name;
+    public IReadOnlyList<string> Aliases => [CommandNames.NewWorkspaceCommand.Alias];
+    public string Summary => Resources.NewWorkspace_Summary;
+
+    public async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken token)
+    {
+        var parsed = Parser.Default.ParseArguments<NewWorkspaceOptions>(args);
+        if (parsed.Errors.Any())
+        {
+            // CommandLine already wrote the usage/errors to stderr.
+            return 2;
+        }
+
+        return await ExecuteAsync(parsed.Value, token);
+    }
+
+    private async Task<int> ExecuteAsync(NewWorkspaceOptions args, CancellationToken token)
+    {
+        var root = fileSystem.Path.GetFullPath(args.Path);
+        if (fileSystem.File.Exists(root))
+        {
+            Write(MessageKind.Error, Resources.NewWorkspace_InvalidPath, args.Path);
+            return 1;
+        }
+
+        fileSystem.Directory.CreateDirectory(root);
+
+        var rdproj = fileSystem.Path.Combine(root, ProjectFile.FileName);
+        if (fileSystem.File.Exists(rdproj) && !args.Force)
+        {
+            Write(MessageKind.Warning, Resources.NewWorkspace_AlreadyExists, root);
+            return 0;
+        }
+
+        var projectName = string.IsNullOrWhiteSpace(args.Name)
+            ? fileSystem.Path.GetFileName(root.TrimEnd('/', '\\'))
+            : args.Name.Trim();
+
+        var project = args.Empty ? new RDCoreProject { Name = projectName } : Scan(root, projectName);
+        await projectWriter.SaveAsync(new ProjectFile(root, project), token);
+
+        Write(MessageKind.Success,
+            string.Format(Resources.NewWorkspace_Created, projectName, rdproj),
+            $"{project.Modules.Length} module(s), {project.OtherFiles.Length} other file(s)");
+        return 0;
+    }
+
+    private RDCoreProject Scan(string root, string projectName)
+    {
+        var modules = new List<RDCoreModule>();
+        var otherFiles = new List<RDCoreFile>();
+        var folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in fileSystem.Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            var relative = fileSystem.Path.GetRelativePath(root, file).Replace('\\', '/');
+            if (relative == ProjectFile.FileName || IsIgnored(relative))
+            {
+                continue;
+            }
+
+            if (ModuleExtensions.Contains(fileSystem.Path.GetExtension(file)))
+            {
+                modules.Add(new RDCoreModule { RelativeUri = relative });
+            }
+            else
+            {
+                otherFiles.Add(new RDCoreFile { RelativeUri = relative });
+            }
+
+            var folder = fileSystem.Path.GetDirectoryName(relative)?.Replace('\\', '/');
+            if (!string.IsNullOrEmpty(folder))
+            {
+                folders.Add(folder);
+            }
+        }
+
+        return new RDCoreProject
+        {
+            Name = projectName,
+            Modules = [.. modules.OrderBy(module => module.RelativeUri, StringComparer.OrdinalIgnoreCase)],
+            OtherFiles = [.. otherFiles.OrderBy(other => other.RelativeUri, StringComparer.OrdinalIgnoreCase)],
+            Folders = [.. folders.OrderBy(folder => folder, StringComparer.OrdinalIgnoreCase)],
+        };
+    }
+
+    // skip dot-files and build output.
+    private static bool IsIgnored(string relativeUri)
+        => relativeUri.Split('/').Any(segment => segment.StartsWith('.') || segment is "bin" or "obj");
+
+    private void Write(MessageKind kind, string body, string verbose)
+        => writer.WriteMessage(new ConsoleMessageBuilder()
+            .WithKind(kind)
+            .WithTitle(Resources.NewWorkspace_Title)
+            .WithMessageBody(body)
+            .WithVerbose(verbose));
+}

--- a/RDCore.CLI/Program.cs
+++ b/RDCore.CLI/Program.cs
@@ -200,6 +200,7 @@ internal class RDCoreConsoleCommandHost : AppHost<RDCoreConsoleCommandApp>
             // native verbs first: NativeCliCommandProvider is enumerated before the extension one, so
             // a native verb wins a name collision.
             .AddSingleton<ICliCommand, DescribeExtensionCommand>()
+            .AddSingleton<ICliCommand, NewWorkspaceCommand>()
             .AddSingleton<ICliCommandProvider, NativeCliCommandProvider>()
             .AddSingleton<ICliCommandProvider, ExtensionCliCommandProvider>()
             .AddSingleton<ICliCommandDispatcher, CliCommandDispatcher>();

--- a/RDCore.CLI/Resources.Designer.cs
+++ b/RDCore.CLI/Resources.Designer.cs
@@ -285,5 +285,50 @@ namespace RDCore.CLI {
                 return ResourceManager.GetString("Warn_ThemingDisabled_Verbose", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Scaffolds a .rdproj workspace at the given path..
+        /// </summary>
+        public static string NewWorkspace_Summary {
+            get {
+                return ResourceManager.GetString("NewWorkspace_Summary", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to New Workspace.
+        /// </summary>
+        public static string NewWorkspace_Title {
+            get {
+                return ResourceManager.GetString("NewWorkspace_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Workspace '{0}' created at {1}.
+        /// </summary>
+        public static string NewWorkspace_Created {
+            get {
+                return ResourceManager.GetString("NewWorkspace_Created", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A .rdproj already exists here; pass --force to overwrite..
+        /// </summary>
+        public static string NewWorkspace_AlreadyExists {
+            get {
+                return ResourceManager.GetString("NewWorkspace_AlreadyExists", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The path points to an existing file, not a directory..
+        /// </summary>
+        public static string NewWorkspace_InvalidPath {
+            get {
+                return ResourceManager.GetString("NewWorkspace_InvalidPath", resourceCulture);
+            }
+        }
     }
 }

--- a/RDCore.CLI/Resources.fr.resx
+++ b/RDCore.CLI/Resources.fr.resx
@@ -215,4 +215,19 @@
   <data name="Command_Available" xml:space="preserve">
     <value>Commandes disponibles :</value>
   </data>
+  <data name="NewWorkspace_Summary" xml:space="preserve">
+    <value>Génère un espace de travail .rdproj au chemin indiqué.</value>
+  </data>
+  <data name="NewWorkspace_Title" xml:space="preserve">
+    <value>Nouvel espace de travail</value>
+  </data>
+  <data name="NewWorkspace_Created" xml:space="preserve">
+    <value>Espace de travail « {0} » créé dans {1}</value>
+  </data>
+  <data name="NewWorkspace_AlreadyExists" xml:space="preserve">
+    <value>Un fichier .rdproj existe déjà ici; utilisez --force pour l'écraser.</value>
+  </data>
+  <data name="NewWorkspace_InvalidPath" xml:space="preserve">
+    <value>Le chemin correspond à un fichier existant, pas à un dossier.</value>
+  </data>
 </root>

--- a/RDCore.CLI/Resources.resx
+++ b/RDCore.CLI/Resources.resx
@@ -217,4 +217,19 @@ Long Live the Cucumber (Latin)</comment>
   <data name="Command_Available" xml:space="preserve">
     <value>Available commands:</value>
   </data>
+  <data name="NewWorkspace_Summary" xml:space="preserve">
+    <value>Scaffolds a .rdproj workspace at the given path.</value>
+  </data>
+  <data name="NewWorkspace_Title" xml:space="preserve">
+    <value>New Workspace</value>
+  </data>
+  <data name="NewWorkspace_Created" xml:space="preserve">
+    <value>Workspace '{0}' created at {1}</value>
+  </data>
+  <data name="NewWorkspace_AlreadyExists" xml:space="preserve">
+    <value>A .rdproj already exists here; pass --force to overwrite.</value>
+  </data>
+  <data name="NewWorkspace_InvalidPath" xml:space="preserve">
+    <value>The path points to an existing file, not a directory.</value>
+  </data>
 </root>

--- a/RDCore.LanguageServer/CoreLanguageServerHost.cs
+++ b/RDCore.LanguageServer/CoreLanguageServerHost.cs
@@ -10,6 +10,7 @@ using RDCore.SDK.Platform;
 using System.IO;
 using System.IO.Abstractions;
 using RDCore.SDK.Server;
+using RDCore.SDK.Server.Logging;
 using RDCore.SDK.Server.Services;
 
 namespace RDCore.LanguageServer;
@@ -51,6 +52,12 @@ internal sealed class CoreLanguageServerHost() : RDCorePlatformServerHost<CoreLa
         builder.AddFile(
             Path.Combine(PlatformEnvironment.Default.LogsDirectory, "RDCore.LanguageServer.log"),
             ResolveTraceLevel(configuration));
+
+        // forward the same narration to the connected client ($/logTrace + window/logMessage,
+        // scrubbed); the file sink above keeps the unredacted copy.
+        builder.Services.AddSingleton<ILoggerProvider>(sp =>
+            new ClientTraceLoggerProvider(() => sp.GetRequiredService<CoreLanguageServerApp>()));
+
         base.ConfigureExternalLogging(services, builder, configuration);
     }
 }

--- a/RDCore.SDK/Server/AppHost.cs
+++ b/RDCore.SDK/Server/AppHost.cs
@@ -221,6 +221,7 @@ public abstract class AppHost<TApp>() : IDisposable
             .AddSingleton<IChildConnectionFactory, ChildConnectionFactory>()
             .AddSingleton<IFileSystem, FileSystem>()
             .AddSingleton<IProjectFileLoader, ProjectFileLoader>()
+            .AddSingleton<IProjectFileWriter, ProjectFileWriter>()
             .AddSingleton<IPlatformEnvironment, PlatformEnvironment>()
             .AddSingleton<IPlatformCompositionService, PlatformCompositionService>()
             .AddSingleton<IExtensionsProvider, ExtensionsClient>()

--- a/RDCore.SDK/Server/Logging/ClientTraceLoggerProvider.cs
+++ b/RDCore.SDK/Server/Logging/ClientTraceLoggerProvider.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace RDCore.SDK.Server.Logging;
+
+/// <summary>
+/// Forwards the outer host's <see cref="ILogger"/> records — the language server's bring-up and
+/// workspace narration — to the connected LSP client via
+/// <see cref="RDCoreServerApp.SendClientTrace"/>. The component's own file-sink copy is unaffected.
+/// This runs on the outer host; the OmniSharp-internal container's records are forwarded by
+/// <see cref="ScrubbingLanguageServerLoggerProvider"/>.
+/// </summary>
+/// <param name="app">
+/// Resolves the running server app. A factory rather than the instance, because the app singleton
+/// may not be constructed yet when the logger factory first materialises this provider.
+/// </param>
+public sealed class ClientTraceLoggerProvider(Func<RDCoreServerApp> app) : ILoggerProvider
+{
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName) => new ClientTraceLogger(app, categoryName);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+}
+
+/// <summary>
+/// The <see cref="ILogger"/> half of <see cref="ClientTraceLoggerProvider"/>.
+/// </summary>
+internal sealed class ClientTraceLogger(Func<RDCoreServerApp> app, string categoryName) : ILogger
+{
+    /// <inheritdoc/>
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    /// <inheritdoc/>
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel == LogLevel.None)
+        {
+            return;
+        }
+
+        var message = LspProtocolLog.ComposeMessage(categoryName, state, exception, formatter);
+        app().SendClientTrace(logLevel, message, exception?.ToString());
+    }
+}

--- a/RDCore.SDK/Server/Logging/LspProtocolLog.cs
+++ b/RDCore.SDK/Server/Logging/LspProtocolLog.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace RDCore.SDK.Server.Logging;
+
+/// <summary>
+/// Shared shaping for the two paths that forward <see cref="ILogger"/> records to an LSP client —
+/// the inner-container <see cref="ScrubbingLanguageServerLoggerProvider"/> and the outer-host
+/// <see cref="ClientTraceLoggerProvider"/> — so the message layout and level mapping cannot drift.
+/// </summary>
+internal static class LspProtocolLog
+{
+    /// <summary>
+    /// The record text in OmniSharp's <c>LanguageServerLogger</c> layout:
+    /// <c>category: message[ - exception] | key='value' …</c>.
+    /// </summary>
+    internal static string ComposeMessage<TState>(string category, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        var pairs = state is IEnumerable<KeyValuePair<string, object>> structured
+            ? string.Join(" ", structured.Where(pair => pair.Key != "{OriginalFormat}").Select(pair => $"{pair.Key}='{pair.Value}'"))
+            : JsonConvert.SerializeObject(state).Replace("\"", "'");
+
+        return category + ": " + formatter(state, exception)
+            + (exception is not null ? " - " + exception : string.Empty)
+            + " | " + pairs;
+    }
+
+    /// <summary>
+    /// Decides, for a record at <paramref name="level"/> and the client's current <c>$/setTrace</c>
+    /// level <paramref name="trace"/>, which client channels carry it: <c>window/logMessage</c> for a
+    /// warning or worse (always, so problems surface even with trace off), <c>$/logTrace</c> for
+    /// narration when trace is on, and whether that trace record includes its verbose detail.
+    /// </summary>
+    internal static (bool LogMessage, bool LogTrace, bool IncludeVerbose) Route(LogLevel level, InitializeTrace trace)
+        => (
+            LogMessage: level is not LogLevel.None && level >= LogLevel.Warning,
+            LogTrace: level is not LogLevel.None && level < LogLevel.Warning && trace != InitializeTrace.Off,
+            IncludeVerbose: trace == InitializeTrace.Verbose);
+
+    /// <summary>
+    /// Maps a <see cref="LogLevel"/> to the LSP <see cref="MessageType"/> for a
+    /// <c>window/logMessage</c>. <see cref="LogLevel.None"/> maps to nothing and returns <c>false</c>.
+    /// </summary>
+    internal static bool TryGetMessageType(LogLevel logLevel, out MessageType messageType)
+    {
+        switch (logLevel)
+        {
+            case LogLevel.Critical:
+            case LogLevel.Error:
+                messageType = MessageType.Error;
+                return true;
+            case LogLevel.Warning:
+                messageType = MessageType.Warning;
+                return true;
+            case LogLevel.Information:
+                messageType = MessageType.Info;
+                return true;
+            case LogLevel.Debug:
+            case LogLevel.Trace:
+                messageType = MessageType.Log;
+                return true;
+            default:
+                messageType = MessageType.Log;
+                return false;
+        }
+    }
+}

--- a/RDCore.SDK/Server/Logging/ScrubbingLanguageServerLoggerProvider.cs
+++ b/RDCore.SDK/Server/Logging/ScrubbingLanguageServerLoggerProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Window;
@@ -48,7 +47,7 @@ internal sealed class ScrubbingLanguageServerLogger(ILanguageServerFacade respon
     {
         // the scoped facade is the server instance, which is null until it finishes constructing;
         // a record logged before then stays in the file log but has no wire yet.
-        if (responseRouter is null || !TryGetMessageType(logLevel, out var messageType))
+        if (responseRouter is null || !LspProtocolLog.TryGetMessageType(logLevel, out var messageType))
         {
             return;
         }
@@ -56,47 +55,7 @@ internal sealed class ScrubbingLanguageServerLogger(ILanguageServerFacade respon
         responseRouter.Window.Log(new LogMessageParams
         {
             Type = messageType,
-            Message = SourcePathAnonymizer.Scrub(ComposeMessage(categoryName, state, exception, formatter), scrubMode),
+            Message = SourcePathAnonymizer.Scrub(LspProtocolLog.ComposeMessage(categoryName, state, exception, formatter), scrubMode),
         });
-    }
-
-    /// <summary>
-    /// The record text in OmniSharp's <c>LanguageServerLogger</c> layout:
-    /// <c>category: message[ - exception] | key='value' …</c>.
-    /// </summary>
-    internal static string ComposeMessage<TState>(string category, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-    {
-        var pairs = state is IEnumerable<KeyValuePair<string, object>> structured
-            ? string.Join(" ", structured.Where(pair => pair.Key != "{OriginalFormat}").Select(pair => $"{pair.Key}='{pair.Value}'"))
-            : JsonConvert.SerializeObject(state).Replace("\"", "'");
-
-        return category + ": " + formatter(state, exception)
-            + (exception is not null ? " - " + exception : string.Empty)
-            + " | " + pairs;
-    }
-
-    // LogLevel -> LSP MessageType; None is not forwarded.
-    internal static bool TryGetMessageType(LogLevel logLevel, out MessageType messageType)
-    {
-        switch (logLevel)
-        {
-            case LogLevel.Critical:
-            case LogLevel.Error:
-                messageType = MessageType.Error;
-                return true;
-            case LogLevel.Warning:
-                messageType = MessageType.Warning;
-                return true;
-            case LogLevel.Information:
-                messageType = MessageType.Info;
-                return true;
-            case LogLevel.Debug:
-            case LogLevel.Trace:
-                messageType = MessageType.Log;
-                return true;
-            default:
-                messageType = MessageType.Log;
-                return false;
-        }
     }
 }

--- a/RDCore.SDK/Server/RDCoreServerApp.cs
+++ b/RDCore.SDK/Server/RDCoreServerApp.cs
@@ -3,12 +3,14 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OmniSharp.Extensions.LanguageServer.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using OmniSharp.Extensions.LanguageServer.Server;
 using RDCore.SDK.Client;
+using RDCore.SDK.ConsoleIO;
 using RDCore.SDK.Platform;
 using RDCore.SDK.Server.Configuration;
 using RDCore.SDK.Server.Handlers;
@@ -76,6 +78,48 @@ public abstract class RDCoreServerApp(
         token.ThrowIfCancellationRequested();
         Server!.SendNotification(notification);
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Forwards one outer-host log record to the connected LSP client, scrubbed through
+    /// <see cref="SourcePathAnonymizer"/>: narration (<paramref name="level"/> below
+    /// <see cref="LogLevel.Warning"/>) rides <c>$/logTrace</c> when the client has asked for trace
+    /// (<c>$/setTrace</c>), and <paramref name="verbose"/> is included only at
+    /// <see cref="InitializeTrace.Verbose"/>; a warning or worse always rides <c>window/logMessage</c>
+    /// so it surfaces even with trace off. A no-op until the server is connected.
+    /// </summary>
+    internal void SendClientTrace(LogLevel level, string message, string? verbose)
+    {
+        if (Server is not { } server)
+        {
+            return;
+        }
+
+        var trace = ServerStateProvider.State is RunningServerState running ? running.Trace : InitializeTrace.Off;
+        var route = LspProtocolLog.Route(level, trace);
+        if (!route.LogMessage && !route.LogTrace)
+        {
+            return;
+        }
+
+        var scrub = options.Value.Server.WireErrorDetail;
+        var scrubbedMessage = SourcePathAnonymizer.Scrub(message, scrub);
+
+        if (route.LogMessage && LspProtocolLog.TryGetMessageType(level, out var messageType))
+        {
+            server.Window.Log(new LogMessageParams { Type = messageType, Message = scrubbedMessage });
+        }
+
+        if (route.LogTrace)
+        {
+            server.LogTrace(new LogTraceParams
+            {
+                Message = scrubbedMessage,
+                Verbose = route.IncludeVerbose && !string.IsNullOrEmpty(verbose)
+                    ? SourcePathAnonymizer.Scrub(verbose, scrub)
+                    : null!,
+            });
+        }
     }
 
     private NamedPipeServerStream _namedPipe = default!;

--- a/RDCore.SDK/Server/RDCoreServerApp.cs
+++ b/RDCore.SDK/Server/RDCoreServerApp.cs
@@ -88,7 +88,7 @@ public abstract class RDCoreServerApp(
     /// <see cref="InitializeTrace.Verbose"/>; a warning or worse always rides <c>window/logMessage</c>
     /// so it surfaces even with trace off. A no-op until the server is connected.
     /// </summary>
-    internal void SendClientTrace(LogLevel level, string message, string? verbose)
+    internal virtual void SendClientTrace(LogLevel level, string message, string? verbose)
     {
         if (Server is not { } server)
         {

--- a/RDCore.SDK/Workspace/ProjectFileWriter.cs
+++ b/RDCore.SDK/Workspace/ProjectFileWriter.cs
@@ -1,4 +1,4 @@
-using System.IO.Abstractions;
+﻿using System.IO.Abstractions;
 using System.Text.Json;
 
 namespace RDCore.SDK.Workspace;

--- a/RDCore.SDK/Workspace/ProjectFileWriter.cs
+++ b/RDCore.SDK/Workspace/ProjectFileWriter.cs
@@ -1,0 +1,38 @@
+using System.IO.Abstractions;
+using System.Text.Json;
+
+namespace RDCore.SDK.Workspace;
+
+/// <summary>
+/// Writes a workspace's <c>.rdproj</c> <see cref="ProjectFile"/> to disk — the write counterpart of
+/// <see cref="IProjectFileLoader"/>. Used to scaffold a new workspace and (eventually) to persist
+/// edits a client makes to the project structure.
+/// </summary>
+public interface IProjectFileWriter
+{
+    /// <summary>
+    /// Serializes <paramref name="project"/> to <c>&lt;project.Uri&gt;/.rdproj</c>, overwriting any
+    /// existing file. The parent directory must exist. <see cref="ProjectFile.IsDirty"/> is not
+    /// consulted — the caller decides whether a write is warranted.
+    /// </summary>
+    /// <param name="project">The project to write; its <see cref="ProjectFile.Uri"/> is the workspace root.</param>
+    /// <param name="token">A token that cancels the write.</param>
+    /// <exception cref="IOException">The file could not be written.</exception>
+    Task SaveAsync(ProjectFile project, CancellationToken token = default);
+}
+
+/// <inheritdoc cref="IProjectFileWriter"/>
+public sealed class ProjectFileWriter(IFileSystem fileSystem) : IProjectFileWriter
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(ProjectFile project, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+
+        var path = fileSystem.Path.Combine(project.Uri, ProjectFile.FileName);
+        await using var stream = fileSystem.File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, project, SerializerOptions, token);
+    }
+}

--- a/RDCore.Tests/Cli/NewWorkspaceCommandTests.cs
+++ b/RDCore.Tests/Cli/NewWorkspaceCommandTests.cs
@@ -1,0 +1,148 @@
+﻿using System.IO.Abstractions.TestingHelpers;
+using NSubstitute;
+using RDCore.CLI.App.Commands;
+using RDCore.SDK.ConsoleIO;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Tests.Cli;
+
+[TestClass]
+public sealed class NewWorkspaceCommandTests
+{
+    private static readonly string Root = Path.Combine(Path.GetTempPath(), "rdcore-new-ws");
+    private static readonly string RdprojPath = Path.Combine(Root, ProjectFile.FileName);
+
+    private static (NewWorkspaceCommand Sut, MockFileSystem Fs) NewSut(params (string RelativePath, string Content)[] files)
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(Root);
+        foreach (var (relative, content) in files)
+        {
+            fs.AddFile(Path.Combine(Root, relative), new MockFileData(content));
+        }
+
+        var sut = new NewWorkspaceCommand(Substitute.For<IConsoleMessageWriter>(), fs, new ProjectFileWriter(fs));
+        return (sut, fs);
+    }
+
+    private static async Task<RDCoreProject> LoadProject(MockFileSystem fs)
+        => (await new ProjectFileLoader(fs).LoadAsync(Root)).ProjectInfo;
+
+    [TestMethod]
+    public async Task Empty_WritesAnEmptyProjectNamedAfterTheDirectory()
+    {
+        var (sut, fs) = NewSut();
+
+        var exit = await sut.ExecuteAsync([Root, "--empty"], CancellationToken.None);
+
+        Assert.AreEqual(0, exit);
+        var project = await LoadProject(fs);
+        Assert.AreEqual("rdcore-new-ws", project.Name);
+        Assert.IsEmpty(project.Modules);
+        Assert.IsEmpty(project.OtherFiles);
+    }
+
+    [TestMethod]
+    public async Task Name_OverridesTheDirectoryName()
+    {
+        var (sut, fs) = NewSut();
+
+        await sut.ExecuteAsync([Root, "--empty", "--name", "MyProject"], CancellationToken.None);
+
+        Assert.AreEqual("MyProject", (await LoadProject(fs)).Name);
+    }
+
+    [TestMethod]
+    public async Task Scan_SortsModuleFilesFromOtherFiles()
+    {
+        var (sut, fs) = NewSut(
+            ("Zeta.bas", "Attribute VB_Name = \"Zeta\""),
+            ("sub/Alpha.cls", "Attribute VB_Name = \"Alpha\""),
+            ("ThisWorkbook.doccls", ""),
+            ("readme.txt", "notes"),
+            ("data/values.json", "{}"));
+
+        var exit = await sut.ExecuteAsync([Root], CancellationToken.None);
+
+        Assert.AreEqual(0, exit);
+        var project = await LoadProject(fs);
+        // classification
+        CollectionAssert.AreEquivalent(
+            new[] { "Zeta.bas", "sub/Alpha.cls", "ThisWorkbook.doccls" },
+            project.Modules.Select(module => module.RelativeUri).ToArray());
+        CollectionAssert.AreEquivalent(
+            new[] { "readme.txt", "data/values.json" },
+            project.OtherFiles.Select(other => other.RelativeUri).ToArray());
+        CollectionAssert.AreEquivalent(new[] { "data", "sub" }, project.Folders);
+        // deterministic order (OrdinalIgnoreCase)
+        var moduleUris = project.Modules.Select(module => module.RelativeUri).ToArray();
+        CollectionAssert.AreEqual(
+            moduleUris.OrderBy(uri => uri, StringComparer.OrdinalIgnoreCase).ToArray(),
+            moduleUris);
+    }
+
+    [TestMethod]
+    public async Task Scan_SkipsBuildOutputAndDotDirectories()
+    {
+        var (sut, fs) = NewSut(
+            ("Real.bas", ""),
+            (".git/config", "x"),
+            ("bin/Debug/app.dll", "x"),
+            ("obj/project.assets.json", "{}"));
+
+        await sut.ExecuteAsync([Root], CancellationToken.None);
+
+        var project = await LoadProject(fs);
+        Assert.AreEqual("Real.bas", project.Modules.Single().RelativeUri);
+        Assert.IsEmpty(project.OtherFiles);
+    }
+
+    [TestMethod]
+    public async Task ExistingRdproj_WithoutForce_IsLeftAlone()
+    {
+        var (sut, fs) = NewSut((ProjectFile.FileName, "{ \"stale\": true }"));
+
+        var exit = await sut.ExecuteAsync([Root], CancellationToken.None);
+
+        Assert.AreEqual(0, exit);
+        Assert.AreEqual("{ \"stale\": true }", fs.File.ReadAllText(RdprojPath));
+    }
+
+    [TestMethod]
+    public async Task ExistingRdproj_WithForce_IsOverwritten()
+    {
+        var (sut, fs) = NewSut((ProjectFile.FileName, "{ \"stale\": true }"), ("Mod.bas", ""));
+
+        var exit = await sut.ExecuteAsync([Root, "--force"], CancellationToken.None);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsFalse(fs.File.ReadAllText(RdprojPath).Contains("stale"));
+        Assert.AreEqual("Mod.bas", (await LoadProject(fs)).Modules.Single().RelativeUri);
+    }
+
+    [TestMethod]
+    public async Task PathIsAnExistingFile_ReturnsOne()
+    {
+        var fs = new MockFileSystem();
+        var filePath = Path.Combine(Path.GetTempPath(), "rdcore-new-ws-file");
+        fs.AddFile(filePath, new MockFileData("not a directory"));
+        var sut = new NewWorkspaceCommand(Substitute.For<IConsoleMessageWriter>(), fs, new ProjectFileWriter(fs));
+
+        var exit = await sut.ExecuteAsync([filePath], CancellationToken.None);
+
+        Assert.AreEqual(1, exit);
+    }
+
+    [TestMethod]
+    public async Task Path_IsCreated_WhenItDoesNotExist()
+    {
+        var fs = new MockFileSystem();
+        var fresh = Path.Combine(Path.GetTempPath(), "rdcore-new-ws-fresh");
+        var sut = new NewWorkspaceCommand(Substitute.For<IConsoleMessageWriter>(), fs, new ProjectFileWriter(fs));
+
+        var exit = await sut.ExecuteAsync([fresh, "--empty"], CancellationToken.None);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsTrue(fs.File.Exists(Path.Combine(fresh, ProjectFile.FileName)));
+    }
+}

--- a/RDCore.Tests/Parser/ParserResilienceTests.cs
+++ b/RDCore.Tests/Parser/ParserResilienceTests.cs
@@ -275,11 +275,30 @@ public sealed class ParserResilienceTests
         // overflow. EnterEveryRule's stack guard converts it to a catchable, located failure.
         var source = "Public Const X = " + new string('(', 2000) + "1" + new string(')', 2000);
 
-        ModuleParseResult result = null!;
-        var thrown = Record(() => result = Parse(source));
+        // parse on a deliberately small stack: whether 2000 frames exhausts the default stack is
+        // platform-dependent (it does on Windows, not on the Linux CI). 256 KB makes the guard fire
+        // everywhere, so the invariant under test — no uncatchable crash — is what's asserted.
+        ModuleParseResult? result = null;
+        Exception? thrown = null;
+        var worker = new Thread(
+            () =>
+            {
+                try
+                {
+                    result = Parse(source);
+                }
+                catch (Exception exception)
+                {
+                    thrown = exception;
+                }
+            },
+            maxStackSize: 256 * 1024);
+        worker.Start();
+        worker.Join();
 
         Assert.IsNull(thrown, $"parsing threw {thrown?.GetType().Name}");
-        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result!.IsSuccess);
     }
 
     [TestMethod]

--- a/RDCore.Tests/Server/ClientTraceLoggerTests.cs
+++ b/RDCore.Tests/Server/ClientTraceLoggerTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using RDCore.SDK.Client;
+using RDCore.SDK.Server;
+using RDCore.SDK.Server.Configuration;
+using RDCore.SDK.Server.Logging;
+using RDCore.SDK.Server.Services;
+using RDCore.SDK.Server.Services.States;
+
+namespace RDCore.Tests.Server;
+
+[TestClass]
+public sealed class ClientTraceLoggerTests
+{
+    private sealed class CapturingServerApp() : RDCoreServerApp(
+        Options.Create(new SdkAppOptions()),
+        Substitute.For<IServerStateProvider>(),
+        Substitute.For<IHealthCheckService<RDCoreServerApp>>(),
+        Substitute.For<ILanguageServerProtocolTransportLayer>(),
+        Substitute.For<ILogger<RDCoreServerApp>>())
+    {
+        public (LogLevel Level, string Message, string? Verbose)? Captured { get; private set; }
+
+        public override CoreServerComponent PlatformComponent => CoreServerComponent.LanguageServer;
+
+        internal override void SendClientTrace(LogLevel level, string message, string? verbose)
+            => Captured = (level, message, verbose);
+
+        protected override void Dispose(bool disposing) { }
+        protected override void ConfigureHandlers(IRDCoreLSPHandlerConfigurationBuilder builder) { }
+        protected override void RegisterServerCapabilities(ILanguageServer server, ClientCapabilities clientCapabilities) { }
+    }
+
+    private static ILogger NewLogger(CapturingServerApp app)
+        => new ClientTraceLoggerProvider(() => app).CreateLogger("RDCore.LS");
+
+    [TestMethod]
+    public void Log_ComposesTheRecord_AndForwardsItToSendClientTrace()
+    {
+        var app = new CapturingServerApp();
+        var boom = new InvalidOperationException("boom");
+
+        NewLogger(app).Log(LogLevel.Information, default, "workspace loaded", boom, (state, _) => state);
+
+        Assert.IsNotNull(app.Captured);
+        Assert.AreEqual(LogLevel.Information, app.Captured!.Value.Level);
+        StringAssert.Contains(app.Captured.Value.Message, "RDCore.LS: workspace loaded");
+        StringAssert.Contains(app.Captured.Value.Message, nameof(InvalidOperationException));
+        StringAssert.Contains(app.Captured.Value.Verbose!, "boom");
+    }
+
+    [TestMethod]
+    public void Log_None_IsNotForwarded()
+    {
+        var app = new CapturingServerApp();
+
+        NewLogger(app).Log(LogLevel.None, default, "x", null, (state, _) => state);
+
+        Assert.IsNull(app.Captured);
+    }
+
+    [TestMethod]
+    public void Log_WithNoException_PassesNullVerbose()
+    {
+        var app = new CapturingServerApp();
+
+        NewLogger(app).Log(LogLevel.Warning, default, "heads up", null, (state, _) => state);
+
+        Assert.IsNull(app.Captured!.Value.Verbose);
+    }
+}

--- a/RDCore.Tests/Server/LspProtocolLogTests.cs
+++ b/RDCore.Tests/Server/LspProtocolLogTests.cs
@@ -6,16 +6,15 @@ using RDCore.SDK.Server.Logging;
 namespace RDCore.Tests.Server;
 
 /// <summary>
-/// The scrubbing protocol logger stands in for OmniSharp's <c>AddLanguageProtocolLogging()</c>: it
-/// forwards the same record text to the client, but a build-machine source path in a logged
-/// exception cannot ride <c>window/logMessage</c> off the machine.
+/// Shared shaping for the two client-forwarding logger paths — message layout, level mapping, and
+/// the <c>window/logMessage</c> vs <c>$/logTrace</c> routing policy.
 /// </summary>
 [TestClass]
-public sealed class ScrubbingLanguageServerLoggerTests
+public sealed class LspProtocolLogTests
 {
     [TestMethod]
-    // OmniSharp's request invoker logs an unhandled handler fault with LogCritical(exception, …); its
-    // protocol logger appends exception.ToString() verbatim. Every forwarding mode must strip the path.
+    // OmniSharp's protocol logger appends exception.ToString() verbatim; every scrub mode must strip
+    // the build-machine path before the composed message reaches the client.
     [DataRow(SourcePathScrubMode.RepoRelative, "RDCore.Parsing/ModuleParser.cs:line 51")]
     [DataRow(SourcePathScrubMode.FileName, "ModuleParser.cs:line 51")]
     [DataRow(SourcePathScrubMode.Redacted, "<source>:line 51")]
@@ -25,21 +24,20 @@ public sealed class ScrubbingLanguageServerLoggerTests
             "boom\r\n" +
             "   at RDCore.Parsing.ModuleParser.Parse() in C:\\Users\\somebody\\src\\RDCore\\RDCore.Parsing\\ModuleParser.cs:line 51");
 
-        var composed = ScrubbingLanguageServerLogger.ComposeMessage(
+        var composed = LspProtocolLog.ComposeMessage(
             "RDCore.Parsing.ModuleParser", state: "parse failed", exception: fault, formatter: (state, _) => state);
         var scrubbed = SourcePathAnonymizer.Scrub(composed, mode);
 
         StringAssert.Contains(scrubbed, expectedFragment);
         Assert.IsFalse(scrubbed.Contains("C:\\"), "the drive-letter prefix must not reach the client");
         Assert.IsFalse(scrubbed.Contains("somebody"), "the build-machine user name must not reach the client");
-        // the exception body is still forwarded, so a client can act on it
         StringAssert.Contains(scrubbed, nameof(InvalidOperationException));
     }
 
     [TestMethod]
     public void ComposeMessage_OmitsTheExceptionSegment_WhenThereIsNone()
     {
-        var composed = ScrubbingLanguageServerLogger.ComposeMessage(
+        var composed = LspProtocolLog.ComposeMessage(
             "Cat", state: "hello", exception: null, formatter: (state, _) => state);
 
         Assert.AreEqual("Cat: hello | 'hello'", composed);
@@ -54,11 +52,29 @@ public sealed class ScrubbingLanguageServerLoggerTests
     [DataRow(LogLevel.Trace, MessageType.Log)]
     public void TryGetMessageType_MapsEveryForwardableLevel(LogLevel level, MessageType expected)
     {
-        Assert.IsTrue(ScrubbingLanguageServerLogger.TryGetMessageType(level, out var type));
+        Assert.IsTrue(LspProtocolLog.TryGetMessageType(level, out var type));
         Assert.AreEqual(expected, type);
     }
 
     [TestMethod]
     public void TryGetMessageType_DoesNotForwardNone()
-        => Assert.IsFalse(ScrubbingLanguageServerLogger.TryGetMessageType(LogLevel.None, out _));
+        => Assert.IsFalse(LspProtocolLog.TryGetMessageType(LogLevel.None, out _));
+
+    [TestMethod]
+    // (level, client $/setTrace) -> (window/logMessage, $/logTrace, verbose)
+    [DataRow(LogLevel.Error, InitializeTrace.Off, true, false, false)]
+    [DataRow(LogLevel.Warning, InitializeTrace.Verbose, true, false, true)]      // warnings never ride the trace channel
+    [DataRow(LogLevel.Information, InitializeTrace.Off, false, false, false)]     // narration is silent with trace off
+    [DataRow(LogLevel.Information, InitializeTrace.Messages, false, true, false)] // narration, no detail
+    [DataRow(LogLevel.Debug, InitializeTrace.Verbose, false, true, true)]        // narration + detail
+    [DataRow(LogLevel.None, InitializeTrace.Verbose, false, false, true)]        // nothing forwarded
+    public void Route_PicksTheChannelsByLevelAndTraceState(
+        LogLevel level, InitializeTrace trace, bool logMessage, bool logTrace, bool includeVerbose)
+    {
+        var route = LspProtocolLog.Route(level, trace);
+
+        Assert.AreEqual(logMessage, route.LogMessage);
+        Assert.AreEqual(logTrace, route.LogTrace);
+        Assert.AreEqual(includeVerbose, route.IncludeVerbose);
+    }
 }

--- a/RDCore.Tests/Workspace/ProjectFileWriterTests.cs
+++ b/RDCore.Tests/Workspace/ProjectFileWriterTests.cs
@@ -1,4 +1,4 @@
-using System.IO.Abstractions.TestingHelpers;
+﻿using System.IO.Abstractions.TestingHelpers;
 using RDCore.SDK.Workspace;
 
 namespace RDCore.Tests.Workspace;

--- a/RDCore.Tests/Workspace/ProjectFileWriterTests.cs
+++ b/RDCore.Tests/Workspace/ProjectFileWriterTests.cs
@@ -1,0 +1,68 @@
+using System.IO.Abstractions.TestingHelpers;
+using RDCore.SDK.Workspace;
+
+namespace RDCore.Tests.Workspace;
+
+[TestClass]
+public sealed class ProjectFileWriterTests
+{
+    private static readonly string Root = Path.Combine(Path.GetTempPath(), "rdcore-writer-ws");
+    private static readonly string ProjectFilePath = Path.Combine(Root, ProjectFile.FileName);
+
+    [TestMethod]
+    public async Task SaveAsync_WritesAnIndentedRdproj_AtTheWorkspaceRoot()
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddDirectory(Root);
+        var project = new ProjectFile(Root, new RDCoreProject
+        {
+            Name = "Probe",
+            Modules = [new RDCoreModule { RelativeUri = "src/Mod1.bas" }],
+        });
+
+        await new ProjectFileWriter(fileSystem).SaveAsync(project);
+
+        Assert.IsTrue(fileSystem.File.Exists(ProjectFilePath));
+        var json = fileSystem.File.ReadAllText(ProjectFilePath);
+        StringAssert.Contains(json, "\n  \"Version\"", "the output should be indented");
+        StringAssert.Contains(json, "\"Probe\"");
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_RoundTripsThroughTheLoader()
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddDirectory(Root);
+        var project = new ProjectFile(Root, new RDCoreProject
+        {
+            Name = "RoundTrip",
+            Modules = [new RDCoreModule { RelativeUri = "A.cls" }, new RDCoreModule { RelativeUri = "B.bas" }],
+            OtherFiles = [new RDCoreFile { RelativeUri = "notes.txt" }],
+            PrecompilerConstants = { ["RDDEBUG"] = "1" },
+        });
+
+        await new ProjectFileWriter(fileSystem).SaveAsync(project);
+        var reloaded = await new ProjectFileLoader(fileSystem).LoadAsync(Root);
+
+        Assert.AreEqual(Root, reloaded.Uri);
+        Assert.AreEqual("RoundTrip", reloaded.ProjectInfo.Name);
+        CollectionAssert.AreEquivalent(
+            new[] { "A.cls", "B.bas" },
+            reloaded.ProjectInfo.Modules.Select(module => module.RelativeUri).ToArray());
+        Assert.AreEqual("notes.txt", reloaded.ProjectInfo.OtherFiles.Single().RelativeUri);
+        Assert.AreEqual("1", reloaded.ProjectInfo.PrecompilerConstants["RDDEBUG"]);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_OverwritesAnExistingRdproj()
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile(ProjectFilePath, new MockFileData("{ \"stale\": true }"));
+
+        await new ProjectFileWriter(fileSystem).SaveAsync(new ProjectFile(Root, new RDCoreProject { Name = "Fresh" }));
+
+        var json = fileSystem.File.ReadAllText(ProjectFilePath);
+        Assert.IsFalse(json.Contains("stale"));
+        StringAssert.Contains(json, "\"Fresh\"");
+    }
+}


### PR DESCRIPTION
- Adds a `new` CLI command to initialize a .rdproj from an existing location
- Adds LSP trace forwarding from the LS to the LSP client
- Fixes failing unit test