### PR TITLE
lsp: module kind comes from the source, not a parser input

### DIFF
--- a/RDCore.LanguageServer/Diagnostics/DocumentDiagnosticsService.cs
+++ b/RDCore.LanguageServer/Diagnostics/DocumentDiagnosticsService.cs
@@ -59,7 +59,7 @@ internal sealed class DocumentDiagnosticsService(
             return DocumentDiagnosticsResult.Fresh(version, []);
         }
 
-        var parseResult = await parsing.ParseDocumentAsync(documentUri, ParsingClientService.ModuleTypeOf(document), token);
+        var parseResult = await parsing.ParseDocumentAsync(documentUri, token);
         var payloadJson = PlatformJson.Serialize(new DiagnoseDocumentPayload(documentUri, version, parseResult));
 
         var reports = await Task.WhenAll(providers.Select(provider => AnalyzeAsync(provider, documentUri, payloadJson, token)));

--- a/RDCore.LanguageServer/Parsing/ParsingClientService.cs
+++ b/RDCore.LanguageServer/Parsing/ParsingClientService.cs
@@ -6,6 +6,7 @@ using RDCore.SDK.Model.AST;
 using RDCore.SDK.Model.AST.Declarations;
 using RDCore.SDK.Model.Source;
 using RDCore.SDK.Platform.Protocol;
+using RDCore.SDK.Workspace;
 
 namespace RDCore.LanguageServer.Parsing;
 
@@ -19,7 +20,7 @@ internal interface IParsingClientService
     /// <summary>
     /// Parses one workspace document, waiting for the parsing server to be ready first, and caches the result.
     /// </summary>
-    Task<ModuleParseResult> ParseDocumentAsync(Uri documentUri, ModuleType moduleType, CancellationToken token);
+    Task<ModuleParseResult> ParseDocumentAsync(Uri documentUri, CancellationToken token);
 
     /// <summary>
     /// Parses every currently-loaded workspace source document. Failures are logged, not thrown.
@@ -37,20 +38,17 @@ internal sealed class ParsingClientService(
     IWorkspaceDocumentService documents,
     ILogger<ParsingClientService> logger) : IParsingClientService
 {
-    private static readonly HashSet<string> _classModuleExtensions =
-        new(StringComparer.OrdinalIgnoreCase) { ".cls", ".frm", ".doccls" };
-
     private readonly ConcurrentDictionary<Uri, ModuleParseResult> _cache = new();
 
     public bool TryGetCached(Uri documentUri, out ModuleParseResult result)
         => _cache.TryGetValue(documentUri, out result!);
 
-    public async Task<ModuleParseResult> ParseDocumentAsync(Uri documentUri, ModuleType moduleType, CancellationToken token)
+    public async Task<ModuleParseResult> ParseDocumentAsync(Uri documentUri, CancellationToken token)
     {
         await orchestration.ParsingService.WaitForReadyAsync(token);
 
         var envelope = await orchestration.ParsingService.SendRequestAsync<ParseDocumentParams, PlatformJsonEnvelope>(
-            new ParseDocumentParams { DocumentUri = documentUri, ModuleType = moduleType }, token);
+            new ParseDocumentParams { DocumentUri = documentUri }, token);
 
         // an error response from the parser comes back as a null envelope; degrade this one document
         // rather than abort the whole workspace parse.
@@ -88,7 +86,7 @@ internal sealed class ParsingClientService(
                 var uri = document.Id.Uri.ToUri();
                 try
                 {
-                    await ParseDocumentAsync(uri, ModuleTypeOf(document), token);
+                    await ParseDocumentAsync(uri, token);
                     parsed++;
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)
@@ -115,11 +113,12 @@ internal sealed class ParsingClientService(
         }
     }
 
-    // review #170: the file extension is a stopgap. Module type is really an attribute concern
-    // (VB_Name etc.) — the AST root node should not vary by module type; resolving this belongs in
-    // semantic space, with the extension only ever driving the workspace-tree icon.
+    // review #170: fixed. The file extension was a stopgap; module kind is a fact of the source
+    // (the VERSION header), not the file name — RD-VBA determines it the same way regardless of
+    // extension (see ModuleHeader). No longer sent to the parser: it never derived the kind from
+    // this hint, only echoed it onto the AST root, which was itself the wrong layer to carry it.
     internal static ModuleType ModuleTypeOf(WorkspaceDocument document)
-        => _classModuleExtensions.Contains(document.Extension) ? ModuleType.ClassModule : ModuleType.StdModule;
+        => ModuleHeader.IsClassModule(document.Text) == true ? ModuleType.ClassModule : ModuleType.StdModule;
 
     private void LogIfEnabled(LogLevel level, string message)
     {

--- a/RDCore.LanguageServer/Symbols/SymbolSyncService.cs
+++ b/RDCore.LanguageServer/Symbols/SymbolSyncService.cs
@@ -47,7 +47,7 @@ internal sealed class SymbolSyncService(
             // collect every parsed module first: the resolver is composed over the whole workspace, so
             // one module's `As SomeType` can bind to a sibling module's Type / Enum declaration.
             Uri? workspaceRoot = null;
-            var modules = new List<(Uri Uri, string Name, ModuleParseResult Parse)>();
+            var modules = new List<(Uri Uri, string Name, ModuleType Kind, ModuleParseResult Parse)>();
             foreach (var document in documents.GetAllDocuments())
             {
                 token.ThrowIfCancellationRequested();
@@ -60,7 +60,9 @@ internal sealed class SymbolSyncService(
                 workspaceRoot ??= new Uri(document.WorkspaceRoot);
                 // the module's programmatic name is its Attribute VB_Name; the file name is the fallback.
                 var moduleName = parseResult.SyntaxTree?.GetDeclaredName() ?? document.Name;
-                modules.Add((new UriBuilder(workspaceRoot) { Fragment = moduleName }.Uri, moduleName, parseResult));
+                // module kind is never a parser input — read it off the raw source, same as the parsing pass.
+                var moduleKind = ParsingClientService.ModuleTypeOf(document);
+                modules.Add((new UriBuilder(workspaceRoot) { Fragment = moduleName }.Uri, moduleName, moduleKind, parseResult));
             }
 
             if (workspaceRoot is null)
@@ -70,13 +72,13 @@ internal sealed class SymbolSyncService(
             }
 
             var workspaceResolver = WorkspaceSymbolResolver.Compose(
-                workspaceRoot, modules.Select(module => (module.Uri, module.Parse)), resolver);
+                workspaceRoot, modules.Select(module => (module.Uri, module.Kind, module.Parse)), resolver);
 
             var totalDefined = 0;
             foreach (var module in modules)
             {
                 token.ThrowIfCancellationRequested();
-                totalDefined += await DefineModuleSymbolsAsync(workspaceRoot, module.Uri, module.Name, module.Parse, workspaceResolver, token);
+                totalDefined += await DefineModuleSymbolsAsync(workspaceRoot, module.Uri, module.Name, module.Kind, module.Parse, workspaceResolver, token);
             }
 
             LogIfEnabled(LogLevel.Information, $"✅ Workspace symbols defined in the environment host ({totalDefined} total)");
@@ -92,10 +94,10 @@ internal sealed class SymbolSyncService(
     }
 
     private async Task<int> DefineModuleSymbolsAsync(
-        Uri workspaceRoot, Uri moduleUri, string moduleName, ModuleParseResult parseResult,
+        Uri workspaceRoot, Uri moduleUri, string moduleName, ModuleType moduleType, ModuleParseResult parseResult,
         ISymbolResolver workspaceResolver, CancellationToken token)
     {
-        var symbols = new SyntaxTreeSymbolProvider(workspaceRoot, moduleUri, parseResult, workspaceResolver).ProvideSymbols();
+        var symbols = new SyntaxTreeSymbolProvider(workspaceRoot, moduleUri, moduleType, parseResult, workspaceResolver).ProvideSymbols();
         var descriptors = SymbolDescriptorProjector.Project(symbols, moduleUri);
 
         var result = await orchestration.RuntimeEnvironment.SendRequestAsync<DefineSymbolsParams, DefineSymbolsResult>(

--- a/RDCore.LanguageServer/Symbols/SyntaxTreeSymbolProvider.cs
+++ b/RDCore.LanguageServer/Symbols/SyntaxTreeSymbolProvider.cs
@@ -20,7 +20,7 @@ namespace RDCore.LanguageServer.Symbols;
 /// are yielded as children of their procedure symbol.
 /// </remarks>
 internal sealed class SyntaxTreeSymbolProvider(
-    Uri workspaceRoot, Uri moduleUri, ModuleParseResult parseResult, ISymbolResolver resolver) : ISymbolProvider
+    Uri workspaceRoot, Uri moduleUri, ModuleType moduleType, ModuleParseResult parseResult, ISymbolResolver resolver) : ISymbolProvider
 {
     public IEnumerable<Symbol> ProvideSymbols()
     {
@@ -67,7 +67,7 @@ internal sealed class SyntaxTreeSymbolProvider(
         }
 
         // a standard module's members are module-scoped; a class module's are instance-scoped.
-        var memberScope = module.ModuleType == ModuleType.ClassModule ? ScopeKind.Instance : ScopeKind.Module;
+        var memberScope = moduleType == ModuleType.ClassModule ? ScopeKind.Instance : ScopeKind.Module;
         var builder = new SymbolBuilder(workspaceRoot, moduleUri, memberScope, resolver);
 
         // module-level names are order-independent, so collect them before walking the members — a

--- a/RDCore.LanguageServer/Symbols/WorkspaceSymbolResolver.cs
+++ b/RDCore.LanguageServer/Symbols/WorkspaceSymbolResolver.cs
@@ -15,23 +15,25 @@ namespace RDCore.LanguageServer.Symbols;
 /// </summary>
 internal static class WorkspaceSymbolResolver
 {
-    // modules are passed as pairs, not a dictionary: Uri equality ignores the fragment, but a module
-    // uri differs from its siblings only in the fragment (workspace#ModuleName).
+    // modules are passed as tuples, not a dictionary: Uri equality ignores the fragment, but a module
+    // uri differs from its siblings only in the fragment (workspace#ModuleName). ModuleType travels
+    // alongside the parse result — the parser is never told a module's kind and does not derive it
+    // (RDCore.SDK.Workspace.ModuleHeader.IsClassModule reads it off the raw source instead).
     public static ISymbolResolver Compose(
-        Uri workspaceRoot, IEnumerable<(Uri ModuleUri, ModuleParseResult Parse)> modules, ISymbolResolver fallback)
+        Uri workspaceRoot, IEnumerable<(Uri ModuleUri, ModuleType ModuleType, ModuleParseResult Parse)> modules, ISymbolResolver fallback)
     {
         var symbols = new List<Symbol>();
-        foreach (var (moduleUri, parseResult) in modules)
+        foreach (var (moduleUri, moduleType, parseResult) in modules)
         {
             // the module symbol itself is the project symbol provider's job at run time; synthesize
             // it here so the scope tree has a module tier to hang the members off (and so a
             // same-module name collision reads as a duplicate declaration, not an ambiguous name).
             var moduleName = moduleUri.Fragment.TrimStart('#');
-            symbols.Add(parseResult.SyntaxTree?.ModuleType == ModuleType.ClassModule
+            symbols.Add(moduleType == ModuleType.ClassModule
                 ? new VBClassModuleSymbol(workspaceRoot, workspaceRoot, moduleName)
                 : new VBStandardModuleSymbol(workspaceRoot, workspaceRoot, moduleName));
 
-            symbols.AddRange(new SyntaxTreeSymbolProvider(workspaceRoot, moduleUri, parseResult, fallback).ProvideSymbols());
+            symbols.AddRange(new SyntaxTreeSymbolProvider(workspaceRoot, moduleUri, moduleType, parseResult, fallback).ProvideSymbols());
         }
 
         return new CompositeSymbolResolver(new ScopeTreeSymbolResolver(ScopeTreeBuilder.Build(symbols)), fallback);

--- a/RDCore.Parsing/Handlers/ParseFullDocumentHandler.cs
+++ b/RDCore.Parsing/Handlers/ParseFullDocumentHandler.cs
@@ -27,13 +27,13 @@ public class ParseFullDocumentHandler(
             throw new InvalidParametersException(request);
         }
 
-        logger.LogInformation("📥 {method}: {uri} ({moduleType})", RDCorePlatformProtocol.ParseFullDocument, uri, request.ModuleType);
+        logger.LogInformation("📥 {method}: {uri}", RDCorePlatformProtocol.ParseFullDocument, uri);
         try
         {
             // LocalPath, not AbsolutePath: a file:// uri's AbsolutePath keeps the leading slash and
             // percent-encoding, so `ReadAllText` can't find it on Windows.
             var content = fileService.ReadAllText(uri.LocalPath);
-            var result = moduleParser.Parse(uri, request.ModuleType, content);
+            var result = moduleParser.Parse(uri, content);
             logger.LogInformation("📤 {uri}: {status}", uri,
                 result.IsSuccess ? "ok" : $"{result.SyntaxErrors.Length} syntax error(s)");
 

--- a/RDCore.Parsing/ModuleParser.cs
+++ b/RDCore.Parsing/ModuleParser.cs
@@ -30,7 +30,7 @@ internal interface ISyntaxNodeProvider : IParseTreeListener
 /// </summary>
 public interface IModuleParser
 {
-    ModuleParseResult Parse(Uri uri, ModuleType moduleType, string content);
+    ModuleParseResult Parse(Uri uri, string content);
 }
 
 /// <param name="serverOptions">Supplies <see cref="SdkServerOptions.WireErrorDetail"/>; optional, the default suits tests.</param>
@@ -42,7 +42,7 @@ internal partial class ModuleParser(
     private readonly ILogger<ModuleParser> _logger = logger ?? NullLogger<ModuleParser>.Instance;
     private readonly SourcePathScrubMode _scrub = serverOptions?.Value.WireErrorDetail ?? SourcePathScrubMode.RepoRelative;
 
-    public ModuleParseResult Parse(Uri uri, ModuleType moduleType, string content)
+    public ModuleParseResult Parse(Uri uri, string content)
     {
         var errorListener = new ErrorListener(uri);
         var precompilerTrivia = ImmutableArray<SyntaxNode>.Empty;
@@ -54,11 +54,11 @@ internal partial class ModuleParser(
             if (string.IsNullOrWhiteSpace(content))
             {
                 // an empty module is valid VBA, not a parse failure.
-                return ModuleParseResult.Success(EmptyModule(uri, moduleType));
+                return ModuleParseResult.Success(EmptyModule(uri));
             }
 
             precompilerTrivia = ParsePrecompilerNodes(content, errorListener, [new PrecompilerDirectiveListener(uri, errorListener)]);
-            var node = new ModuleNode(new SyntaxNodeId(uri.AbsolutePath, []), new(uri, SourceRange.Empty), precompilerTrivia, moduleType);
+            var node = new ModuleNode(new SyntaxNodeId(uri.AbsolutePath, []), new(uri, SourceRange.Empty), precompilerTrivia);
 
             var sanitized = PrecompilerNodePattern().Replace(content, match => new string(' ', match.Length));
             var listener = ParseWithFallback(sanitized, errorListener, () => declarations = new DeclarationsParseTreeListener(uri, node, errorListener));
@@ -101,8 +101,8 @@ internal partial class ModuleParser(
         }
     }
 
-    private static ModuleNode EmptyModule(Uri uri, ModuleType moduleType)
-        => new(new SyntaxNodeId(uri.AbsolutePath, []), new(uri, SourceRange.Empty), [], moduleType);
+    private static ModuleNode EmptyModule(Uri uri)
+        => new(new SyntaxNodeId(uri.AbsolutePath, []), new(uri, SourceRange.Empty), []);
 
     // ANTLR's input stream and the precompiler-line regexes (RegexOptions.Multiline) only treat \n as
     // a line boundary, and a leading BOM would land in column 0 of the first token. Fold every line

--- a/RDCore.SDK/Model/AST/Declarations/ModuleNode.cs
+++ b/RDCore.SDK/Model/AST/Declarations/ModuleNode.cs
@@ -7,9 +7,15 @@ namespace RDCore.SDK.Model.AST.Declarations;
 /// <summary>
 /// An AST root node, representing an entire module.
 /// </summary>
+/// <remarks>
+/// A module's <em>kind</em> — standard vs. class vs. document/form — is not a syntactic fact this
+/// node carries: the parser is never told it and does not derive it (the grammar drops the
+/// <c>VERSION</c>/<c>BEGIN…END</c> header rather than keeping it as trivia). It is a property of the
+/// <c>Attribute VB_*</c> block a caller reads off the parsed tree, or of the raw source
+/// (<c>RDCore.SDK.Workspace.ModuleHeader.IsClassModule</c>), on whichever side of the pipe needs it.
+/// </remarks>
 /// <param name="Identity">A unique identifier for this specific syntax node.</param>
 /// <param name="Location">The source location of this module; the <c>SourceRange</c> is invalid.</param>
 /// <param name="Children">An immutable array containing all AST nodes of this module.</param>
-/// <param name="ModuleType">The type of module this AST is for.</param>
-public record class ModuleNode(SyntaxNodeId Identity, SourceLocation Location, ImmutableArray<SyntaxNode> Children, ModuleType ModuleType)
+public record class ModuleNode(SyntaxNodeId Identity, SourceLocation Location, ImmutableArray<SyntaxNode> Children)
     : SyntaxNode(Identity, Location, Children);

--- a/RDCore.SDK/Platform/Protocol/ParseDocumentParams.cs
+++ b/RDCore.SDK/Platform/Protocol/ParseDocumentParams.cs
@@ -2,7 +2,6 @@
 using OmniSharp.Extensions.JsonRpc;
 using RDCore.SDK.Client;
 using RDCore.SDK.Model.AST;
-using RDCore.SDK.Model.AST.Declarations;
 using RDCore.SDK.Model.Source;
 
 namespace RDCore.SDK.Platform.Protocol;
@@ -23,10 +22,6 @@ public record class ParseDocumentParams : IRequest, IRequest<PlatformJsonEnvelop
     /// The <c>Uri</c> of the document to parse.
     /// </summary>
     public Uri? DocumentUri { get; init; } = default;
-    /// <summary>
-    /// The type of module (for the root AST node).
-    /// </summary>
-    public ModuleType ModuleType { get; init; } = ModuleType.StdModule;
     /// <summary>
     /// The fragment of source code to parse.
     /// </summary>

--- a/RDCore.Tests/Cli/WorkspaceSymbolPipelineTests.cs
+++ b/RDCore.Tests/Cli/WorkspaceSymbolPipelineTests.cs
@@ -27,8 +27,14 @@ public sealed class WorkspaceSymbolPipelineTests
         + "Public Function Add(ByVal a As Long, ByVal b As Long) As Long\r\n"
         + "End Function\r\n";
 
-    // Event is a declarations-section-only construct, so it must precede the Property block.
-    private const string Class1 = "Attribute VB_Name = \"Class1\"\r\n"
+    // Event is a declarations-section-only construct, so it must precede the Property block. The
+    // VERSION header is what makes this a class module now that module kind comes from the source,
+    // not the .cls extension (RDCore.SDK.Workspace.ModuleHeader).
+    private const string Class1 = "VERSION 1.0 CLASS\r\n"
+        + "BEGIN\r\n"
+        + "  MultiUse = -1  'True\r\n"
+        + "END\r\n"
+        + "Attribute VB_Name = \"Class1\"\r\n"
         + "Private mWidget As Object\r\n"
         + "Public Event Changed(ByVal NewValue As Long)\r\n"
         + "Public Property Get Widget() As Object\r\n"
@@ -80,17 +86,19 @@ public sealed class WorkspaceSymbolPipelineTests
         foreach (var module in project.ProjectInfo.Modules)
         {
             var path = Path.Combine(Root, module.RelativeUri);
-            var moduleType = path.EndsWith(".cls") ? ModuleType.ClassModule : ModuleType.StdModule;
+            var source = fs.File.ReadAllText(path);
+            // module kind is a fact of the source (the VERSION header), not the file extension.
+            var moduleType = ModuleHeader.IsClassModule(source) == true ? ModuleType.ClassModule : ModuleType.StdModule;
             var workspaceRoot = new Uri(project.Uri);
 
-            var parseResult = parser.Parse(new Uri(path), moduleType, fs.File.ReadAllText(path));
+            var parseResult = parser.Parse(new Uri(path), source);
 
             // the language server names a module by its parsed VB_Name; the environment host resolved
             // the same name when it composed the module symbol above.
             var name = parseResult.SyntaxTree?.GetDeclaredName() ?? module.DefaultName;
             var moduleUri = new UriBuilder(workspaceRoot) { Fragment = name }.Uri;
 
-            var symbols = new SyntaxTreeSymbolProvider(workspaceRoot, moduleUri, parseResult, resolver).ProvideSymbols();
+            var symbols = new SyntaxTreeSymbolProvider(workspaceRoot, moduleUri, moduleType, parseResult, resolver).ProvideSymbols();
             var descriptors = SymbolDescriptorProjector.Project(symbols, moduleUri);
 
             results[name] = await handler.Handle(new DefineSymbolsParams

--- a/RDCore.Tests/Diagnostics/DiagnoseDocumentHandlerTests.cs
+++ b/RDCore.Tests/Diagnostics/DiagnoseDocumentHandlerTests.cs
@@ -38,7 +38,7 @@ public sealed class DiagnoseDocumentHandlerTests
     private static DiagnoseDocumentRequest RequestFor(string source, out ModuleParseResult parseResult, int version = 1)
     {
         var uri = TestUri.TestModuleUri();
-        parseResult = new ModuleParser().Parse(uri, ModuleType.StdModule, source);
+        parseResult = new ModuleParser().Parse(uri, source);
         return new DiagnoseDocumentRequest
         {
             Json = PlatformJson.Serialize(new DiagnoseDocumentPayload(uri, version, parseResult)),

--- a/RDCore.Tests/LanguageServer/DocumentDiagnosticsServiceTests.cs
+++ b/RDCore.Tests/LanguageServer/DocumentDiagnosticsServiceTests.cs
@@ -10,7 +10,6 @@ using RDCore.LanguageServer.Workspace.Services;
 using RDCore.Parsing;
 using RDCore.SDK.Client;
 using RDCore.SDK.Extensibility;
-using RDCore.SDK.Model.AST.Declarations;
 using RDCore.SDK.Platform.Protocol;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
@@ -38,8 +37,8 @@ public sealed class DocumentDiagnosticsServiceTests
         => _documents.GetAllDocuments().Returns([first], [then]);
 
     private void ParseYields()
-        => _parsing.ParseDocumentAsync(Arg.Any<Uri>(), Arg.Any<ModuleType>(), Arg.Any<CancellationToken>())
-            .Returns(new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, "Public Sub Foo()\r\nEnd Sub"));
+        => _parsing.ParseDocumentAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
+            .Returns(new ModuleParser().Parse(TestUri.TestModuleUri(), "Public Sub Foo()\r\nEnd Sub"));
 
     private static Diagnostic Diag(int line, string code = "VBC01027", string source = "RDCore", string message = "Syntax error")
         => new()
@@ -87,7 +86,7 @@ public sealed class DocumentDiagnosticsServiceTests
         Assert.AreEqual("v1", result.ResultId);
         Assert.IsFalse(result.Unchanged);
         Assert.IsEmpty(result.Diagnostics);
-        await _parsing.DidNotReceive().ParseDocumentAsync(Arg.Any<Uri>(), Arg.Any<ModuleType>(), Arg.Any<CancellationToken>());
+        await _parsing.DidNotReceive().ParseDocumentAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>());
     }
 
     [TestMethod]

--- a/RDCore.Tests/LanguageServer/EvilTestCase2ResolverTests.cs
+++ b/RDCore.Tests/LanguageServer/EvilTestCase2ResolverTests.cs
@@ -59,10 +59,10 @@ public sealed class EvilTestCase2ResolverTests
     private static (ISymbolResolver Resolver, Uri ModuleUri, Uri ProcUri) Compose()
     {
         var moduleUri = new UriBuilder(WorkspaceRoot) { Fragment = "MyModule" }.Uri;
-        var parse = new ModuleParser().Parse(new Uri("file:///c:/ws/MyModule.bas"), ModuleType.StdModule, MyModuleSource);
+        var parse = new ModuleParser().Parse(new Uri("file:///c:/ws/MyModule.bas"), MyModuleSource);
 
         var resolver = WorkspaceSymbolResolver.Compose(
-            WorkspaceRoot, [(moduleUri, parse)], new IntrinsicSymbolResolver());
+            WorkspaceRoot, [(moduleUri, ModuleType.StdModule, parse)], new IntrinsicSymbolResolver());
 
         var procUri = new UriBuilder(WorkspaceRoot) { Fragment = "MyModule.MyProc1" }.Uri;
         return (resolver, moduleUri, procUri);

--- a/RDCore.Tests/LanguageServer/ParsingClientServiceTests.cs
+++ b/RDCore.Tests/LanguageServer/ParsingClientServiceTests.cs
@@ -19,7 +19,7 @@ public sealed class ParsingClientServiceTests
     private static readonly string Root = Path.Combine(Path.GetTempPath(), "rdcore-ws");
 
     private static PlatformJsonEnvelope SampleEnvelope
-        => PlatformJsonEnvelope.Of(new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, "Public Sub Foo()\r\nEnd Sub"));
+        => PlatformJsonEnvelope.Of(new ModuleParser().Parse(TestUri.TestModuleUri(), "Public Sub Foo()\r\nEnd Sub"));
 
     private static (ParsingClientService Sut, IRDCoreClientApp Parser, IWorkspaceDocumentService Documents) Build()
     {
@@ -41,11 +41,11 @@ public sealed class ParsingClientServiceTests
         var (sut, parser, _) = Build();
         var uri = new Uri("file:///c:/ws/src/Mod1.bas");
 
-        var result = await sut.ParseDocumentAsync(uri, ModuleType.StdModule, CancellationToken.None);
+        var result = await sut.ParseDocumentAsync(uri, CancellationToken.None);
 
         await parser.Received(1).WaitForReadyAsync(Arg.Any<CancellationToken>());
         await parser.Received(1).SendRequestAsync<ParseDocumentParams, PlatformJsonEnvelope>(
-            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == uri && p.ModuleType == ModuleType.StdModule),
+            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == uri),
             Arg.Any<CancellationToken>());
 
         Assert.IsTrue(result.IsSuccess);
@@ -54,7 +54,7 @@ public sealed class ParsingClientServiceTests
     }
 
     [TestMethod]
-    public async Task ParseWorkspaceAsync_ParsesEachDocument_WithModuleTypeFromExtension()
+    public async Task ParseWorkspaceAsync_ParsesEachDocument()
     {
         var (sut, parser, documents) = Build();
         var module = new WorkspaceDocument("src/Mod1.bas", Root, "x");
@@ -64,11 +64,24 @@ public sealed class ParsingClientServiceTests
         await sut.ParseWorkspaceAsync(CancellationToken.None);
 
         await parser.Received(1).SendRequestAsync<ParseDocumentParams, PlatformJsonEnvelope>(
-            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == module.Id.Uri.ToUri() && p.ModuleType == ModuleType.StdModule),
+            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == module.Id.Uri.ToUri()),
             Arg.Any<CancellationToken>());
         await parser.Received(1).SendRequestAsync<ParseDocumentParams, PlatformJsonEnvelope>(
-            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == klass.Id.Uri.ToUri() && p.ModuleType == ModuleType.ClassModule),
+            Arg.Is<ParseDocumentParams>(p => p.DocumentUri == klass.Id.Uri.ToUri()),
             Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public void ModuleTypeOf_ReadsTheVersionHeader_NotTheExtension()
+    {
+        // the header, not the .cls/.bas extension, is the signal (RDCore.SDK.Workspace.ModuleHeader).
+        var classWithoutClsExtension = new WorkspaceDocument(
+            "src/Weird.txt", Root, "VERSION 1.0 CLASS\r\nBEGIN\r\n  MultiUse = -1  'True\r\nEND\r\nAttribute VB_Name = \"Weird\"\r\n");
+        var standardWithClsExtension = new WorkspaceDocument(
+            "src/NotReally.cls", Root, "Attribute VB_Name = \"NotReally\"\r\n");
+
+        Assert.AreEqual(ModuleType.ClassModule, ParsingClientService.ModuleTypeOf(classWithoutClsExtension));
+        Assert.AreEqual(ModuleType.StdModule, ParsingClientService.ModuleTypeOf(standardWithClsExtension));
     }
 
     [TestMethod]
@@ -89,7 +102,7 @@ public sealed class ParsingClientServiceTests
         parser.SendRequestAsync<ParseDocumentParams, PlatformJsonEnvelope>(default!, default).ReturnsForAnyArgs((PlatformJsonEnvelope)null!);
         var uri = new Uri("file:///c:/ws/src/Mod1.bas");
 
-        var result = await sut.ParseDocumentAsync(uri, ModuleType.StdModule, CancellationToken.None);
+        var result = await sut.ParseDocumentAsync(uri, CancellationToken.None);
 
         Assert.IsFalse(result.IsSuccess);
         Assert.IsTrue(sut.TryGetCached(uri, out var cached));
@@ -111,7 +124,7 @@ public sealed class ParsingClientServiceTests
     [TestMethod]
     public void PlatformJsonEnvelope_RoundTripsAPolymorphicParseResult()
     {
-        var original = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule,
+        var original = new ModuleParser().Parse(TestUri.TestModuleUri(),
             "Public Function Add(ByVal a As Long) As Long\r\nEnd Function");
 
         var result = PlatformJsonEnvelope.Of(original).Unwrap<ModuleParseResult>();

--- a/RDCore.Tests/LanguageServer/SymbolDescriptorProjectorTests.cs
+++ b/RDCore.Tests/LanguageServer/SymbolDescriptorProjectorTests.cs
@@ -15,8 +15,8 @@ public sealed class SymbolDescriptorProjectorTests
 
     private static SymbolDescriptor[] Project(string source)
     {
-        var parseResult = new ModuleParser().Parse(new Uri("file:///c:/ws/src/Mod1.bas"), ModuleType.StdModule, source);
-        var symbols = new SyntaxTreeSymbolProvider(WorkspaceRoot, ModuleUri, parseResult, new IntrinsicSymbolResolver()).ProvideSymbols();
+        var parseResult = new ModuleParser().Parse(new Uri("file:///c:/ws/src/Mod1.bas"), source);
+        var symbols = new SyntaxTreeSymbolProvider(WorkspaceRoot, ModuleUri, ModuleType.StdModule, parseResult, new IntrinsicSymbolResolver()).ProvideSymbols();
         return [.. SymbolDescriptorProjector.Project(symbols, ModuleUri)];
     }
 

--- a/RDCore.Tests/LanguageServer/SymbolSyncServiceTests.cs
+++ b/RDCore.Tests/LanguageServer/SymbolSyncServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class SymbolSyncServiceTests
     private static readonly string Root = Path.Combine(Path.GetTempPath(), "rdcore-sync-ws");
 
     private static ModuleParseResult Parse(string source)
-        => new ModuleParser().Parse(new Uri(Path.Combine(Root, "src", "Mod1.bas")), ModuleType.StdModule, source);
+        => new ModuleParser().Parse(new Uri(Path.Combine(Root, "src", "Mod1.bas")), source);
 
     private static (SymbolSyncService Sut, IRDCoreClientApp Host) Build(
         ModuleParseResult? cached, bool providesCapability = true, DefineSymbolsResult? response = null)

--- a/RDCore.Tests/LanguageServer/SyntaxTreeSymbolProviderTests.cs
+++ b/RDCore.Tests/LanguageServer/SyntaxTreeSymbolProviderTests.cs
@@ -21,9 +21,9 @@ public sealed class SyntaxTreeSymbolProviderTests
 
     private static List<Symbol> Provide(string source, ISymbolResolver? resolver = null, ModuleType moduleType = ModuleType.StdModule)
     {
-        var parseResult = new ModuleParser().Parse(TestUri.TestModuleUri(), moduleType, source);
+        var parseResult = new ModuleParser().Parse(TestUri.TestModuleUri(), source);
         var provider = new SyntaxTreeSymbolProvider(
-            WorkspaceRoot, ModuleUri, parseResult, resolver ?? Substitute.For<ISymbolResolver>());
+            WorkspaceRoot, ModuleUri, moduleType, parseResult, resolver ?? Substitute.For<ISymbolResolver>());
         return [.. provider.ProvideSymbols()];
     }
 

--- a/RDCore.Tests/LanguageServer/WorkspaceSymbolResolverTests.cs
+++ b/RDCore.Tests/LanguageServer/WorkspaceSymbolResolverTests.cs
@@ -20,17 +20,18 @@ public sealed class WorkspaceSymbolResolverTests
 
     private static Uri ModuleUri(string name) => new UriBuilder(WorkspaceRoot) { Fragment = name }.Uri;
 
-    private static (Uri Uri, ModuleParseResult Parse) Module(string name, string body)
-        => (ModuleUri(name), new ModuleParser().Parse(
-            new Uri($"file:///c:/ws/{name}.bas"), ModuleType.StdModule, $"Attribute VB_Name = \"{name}\"\r\n{body}"));
+    private static (Uri Uri, ModuleType ModuleType, ModuleParseResult Parse) Module(string name, string body)
+        => (ModuleUri(name), ModuleType.StdModule, new ModuleParser().Parse(
+            new Uri($"file:///c:/ws/{name}.bas"), $"Attribute VB_Name = \"{name}\"\r\n{body}"));
 
-    private static List<Symbol> Resolve(string moduleName, string moduleBody, params (Uri Uri, ModuleParseResult Parse)[] siblings)
+    private static List<Symbol> Resolve(
+        string moduleName, string moduleBody, params (Uri Uri, ModuleType ModuleType, ModuleParseResult Parse)[] siblings)
     {
         var target = Module(moduleName, moduleBody);
         var resolver = WorkspaceSymbolResolver.Compose(
             WorkspaceRoot, [.. siblings, target], new IntrinsicSymbolResolver());
 
-        return [.. new SyntaxTreeSymbolProvider(WorkspaceRoot, target.Uri, target.Parse, resolver).ProvideSymbols()];
+        return [.. new SyntaxTreeSymbolProvider(WorkspaceRoot, target.Uri, target.ModuleType, target.Parse, resolver).ProvideSymbols()];
     }
 
     [TestMethod]

--- a/RDCore.Tests/Model/AST/SyntaxNodeSerializationTests.cs
+++ b/RDCore.Tests/Model/AST/SyntaxNodeSerializationTests.cs
@@ -67,7 +67,7 @@ public sealed class SyntaxNodeSerializationTests
         var pcElse = new PrecompilerElseBlockStatementNode(Id(2, 1), loc, []);
         var trivia = new PrecompilerTriviaNode(Id(2), loc, [pcName, pcElse], "#If RDDEBUG Then");
 
-        SyntaxNode module = new ModuleNode(Id(), loc, [typedDecl, elseBlock, trivia], ModuleType.StdModule);
+        SyntaxNode module = new ModuleNode(Id(), loc, [typedDecl, elseBlock, trivia]);
 
         var json = JsonSerializer.Serialize(module, Options);
         var rehydrated = JsonSerializer.Deserialize<SyntaxNode>(json, Options);
@@ -107,7 +107,7 @@ public sealed class SyntaxNodeSerializationTests
             #End If
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var treeJson = JsonSerializer.Serialize(result.SyntaxTree, Options);

--- a/RDCore.Tests/Parser/DeclarationPassParserTests.cs
+++ b/RDCore.Tests/Parser/DeclarationPassParserTests.cs
@@ -20,7 +20,7 @@ public class DeclarationPassParserTests
         var content = "invalid content";
 
         // act
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
 
         // assert
         Assert.IsFalse(result.IsSuccess);
@@ -36,7 +36,7 @@ public class DeclarationPassParserTests
     [DataRow("#Const A = 1\r\n#Const B = A + 1\r\n#If B Then\r\nPublic X As Long\r\n#End If", DisplayName = "#Const B = A + 1")]
     public void OperatorInConditional_PreservesPrecompilerTrivia(string content)
     {
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
 
         Assert.IsNotEmpty(result.PrecompilerTrivia);
     }
@@ -58,7 +58,7 @@ public class DeclarationPassParserTests
             """;
         var uri = TestUri.TestModuleUri();
 
-        var result = new ModuleParser().Parse(uri, ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(uri, content);
 
         Assert.IsFalse(result.IsSuccess);
         Assert.IsNotEmpty(result.SyntaxErrors);
@@ -84,7 +84,7 @@ public class DeclarationPassParserTests
         var uri = TestUri.TestModuleUri();
         var sut = new ModuleParser();
 
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
 
         Assert.IsNotNull(result.SyntaxTree);
         Assert.HasCount(1, result.SyntaxTree.Children.OfType<ModuleOptionDirectiveNode>());
@@ -134,7 +134,7 @@ End Sub
         var sut = new ModuleParser();
 
         // act
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
 
         // assert
         Assert.IsNotNull(result.SyntaxTree);
@@ -150,7 +150,7 @@ End Sub
         var sut = new ModuleParser();
 
         // act
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
         var localVariables = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>()
             .SelectMany(member => member.Children.OfType<VariableDeclarationNode>())
             .ToArray();
@@ -168,7 +168,7 @@ End Sub
         var sut = new ModuleParser();
 
         // act
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
         var localConstants = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>()
             .SelectMany(member => member.Children.OfType<ConstantDeclarationNode>())
             .ToArray();
@@ -186,7 +186,7 @@ End Sub
         var sut = new ModuleParser();
 
         // act
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
         var lineLabels = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>()
             .SelectMany(member => member.Children.OfType<LineLabelNode>())
             .ToArray();
@@ -203,7 +203,7 @@ End Sub
         var sut = new ModuleParser();
 
         // act
-        var result = sut.Parse(uri, ModuleType.StdModule, content);
+        var result = sut.Parse(uri, content);
         if (result.IsSuccess)
         {
             var ast = result.SyntaxTree!;
@@ -231,7 +231,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var json = JsonSerializer.Serialize(result.SyntaxTree!);
@@ -258,7 +258,7 @@ End Sub
             Public Const Answer As Long = 42
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var literal = Descendants(result.SyntaxTree!).OfType<LiteralExpressionNode>().SingleOrDefault();
@@ -276,7 +276,7 @@ End Sub
     [DataRow("Public Const N = - -7", 7L)]
     public void NegativeConstant_KeepsItsSign(string source, long expected)
     {
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, source);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), source);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var literal = Descendants(result.SyntaxTree!).OfType<LiteralExpressionNode>().Single();
@@ -301,7 +301,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var member = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single();
@@ -322,7 +322,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var locals = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single()
@@ -345,7 +345,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var locals = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single()
@@ -379,7 +379,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var redim = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single()
@@ -404,7 +404,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var redim = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single()
@@ -423,7 +423,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var member = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single();
@@ -442,7 +442,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.ClassModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var redim = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single()
@@ -461,7 +461,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var redims = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single()
@@ -483,7 +483,7 @@ End Sub
             End Sub
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var member = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>().Single();
@@ -500,7 +500,7 @@ End Sub
             End Type
             """;
 
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, content);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), content);
         Assert.IsTrue(result.IsSuccess, result.SyntaxErrors.Length == 0 ? "" : result.SyntaxErrors[0]!.Description);
 
         var udt = result.SyntaxTree!.Children.OfType<MemberDeclarationNode>()

--- a/RDCore.Tests/Parser/ModuleNodeExtensionsTests.cs
+++ b/RDCore.Tests/Parser/ModuleNodeExtensionsTests.cs
@@ -6,9 +6,9 @@ namespace RDCore.Tests.Parser;
 [TestClass]
 public sealed class ModuleNodeExtensionsTests
 {
-    private static ModuleNode Parse(string source, ModuleType moduleType = ModuleType.StdModule)
+    private static ModuleNode Parse(string source)
     {
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), moduleType, source);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), source);
         Assert.IsNotNull(result.SyntaxTree, "expected a parsed module");
         return result.SyntaxTree;
     }

--- a/RDCore.Tests/Parser/NumericLiteralTypeHintTests.cs
+++ b/RDCore.Tests/Parser/NumericLiteralTypeHintTests.cs
@@ -30,7 +30,7 @@ public sealed class NumericLiteralTypeHintTests
 
     private static LiteralExpressionNode LiteralOf(string constName)
     {
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, _module);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), _module);
         Assert.IsNotNull(result.SyntaxTree);
 
         var constant = Descendants(result.SyntaxTree!)
@@ -41,7 +41,7 @@ public sealed class NumericLiteralTypeHintTests
 
     private static Dictionary<string, Type> LiteralTypesByConstName()
     {
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, _module);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), _module);
         Assert.IsNotNull(result.SyntaxTree);
 
         return Descendants(result.SyntaxTree!)
@@ -102,7 +102,7 @@ public sealed class NumericLiteralTypeHintTests
     [DataRow("#Const N = 99999%\r\n#If N Then\r\n#End If", DisplayName = "#Const pass")]
     public void OverflowingLiteral_IsALocatedSyntaxError(string source)
     {
-        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), ModuleType.StdModule, source);
+        var result = new ModuleParser().Parse(TestUri.TestModuleUri(), source);
 
         Assert.IsFalse(result.IsSuccess);
         var overflow = result.SyntaxErrors.Single(e => e.VBCompileErrorId == SDK.Model.Errors.VBCompileErrorId.NumericLiteralOverflow);

--- a/RDCore.Tests/Parser/ParserResilienceTests.cs
+++ b/RDCore.Tests/Parser/ParserResilienceTests.cs
@@ -20,7 +20,7 @@ public sealed class ParserResilienceTests
     private static readonly Uri Uri = TestUri.TestModuleUri();
 
     private static ModuleParseResult Parse(string source)
-        => new ModuleParser().Parse(Uri, ModuleType.StdModule, source);
+        => new ModuleParser().Parse(Uri, source);
 
     [TestMethod]
     // the whole point: none of these — valid, half-typed, or garbage — may throw.

--- a/RDCore.Tests/Parser/SourceNormalizationTests.cs
+++ b/RDCore.Tests/Parser/SourceNormalizationTests.cs
@@ -18,7 +18,7 @@ public sealed class SourceNormalizationTests
     private static readonly Uri Uri = TestUri.TestModuleUri();
 
     private static ModuleParseResult Parse(string source)
-        => new ModuleParser().Parse(Uri, ModuleType.StdModule, source);
+        => new ModuleParser().Parse(Uri, source);
 
     [TestMethod]
     [DataRow("\r", DisplayName = "CR only")]

--- a/RDCore.Tests/Platform/DiagnoseDocumentSerializationTests.cs
+++ b/RDCore.Tests/Platform/DiagnoseDocumentSerializationTests.cs
@@ -34,7 +34,7 @@ public sealed class DiagnoseDocumentSerializationTests
     public void DiagnoseDocumentPayload_RoundTripsWithItsAstAndSyntaxErrors()
     {
         var uri = TestUri.TestModuleUri();
-        var parseResult = new ModuleParser().Parse(uri, ModuleType.StdModule, SplitConditionalModule);
+        var parseResult = new ModuleParser().Parse(uri, SplitConditionalModule);
         Assert.IsFalse(parseResult.IsSuccess, "the fixture must produce syntax errors");
         Assert.IsNotEmpty(parseResult.SyntaxErrors);
 
@@ -59,7 +59,7 @@ public sealed class DiagnoseDocumentSerializationTests
     public void DiagnoseDocumentPayload_RoundTripsACleanParse()
     {
         var uri = TestUri.TestModuleUri();
-        var parseResult = new ModuleParser().Parse(uri, ModuleType.StdModule, CleanModule);
+        var parseResult = new ModuleParser().Parse(uri, CleanModule);
         Assert.IsTrue(parseResult.IsSuccess);
 
         var once = PlatformJson.Deserialize<DiagnoseDocumentPayload>(


### PR DESCRIPTION
ModuleType was decided by file extension in ParsingClientService and pushed into ModuleParser.Parse as a hint the parser only ever echoed onto ModuleNode.ModuleType — never derived, never checked. Flagged as a stopgap in review #170.

ParseDocumentParams.ModuleType and the moduleType parameter of ModuleParser.Parse / IModuleParser.Parse / EmptyModule are gone; the parser only ever parses now. ModuleNode drops the field entirely — a module's kind was never a syntactic fact it could derive on its own (the grammar consumes the VERSION/BEGIN...END header but NodeBuilder does not keep it as trivia yet).

ParsingClientService.ModuleTypeOf is source-based instead: ModuleHeader.IsClassModule(document.Text), the same VERSION-header check ProjectSymbolProvider already uses on the CLI/env-host side (#171). LS symbol extraction (SyntaxTreeSymbolProvider, WorkspaceSymbolResolver, SymbolSyncService) now takes ModuleType as an explicit parameter, computed once per module from the document text, instead of reading it off the AST root.

Tier 2 (preserving the VERSION/BEGIN...END header as trivia, for Document/UserForm kinds) is its own follow-up:
C:\Dev\Claude\rdcore-module-kind-from-attributes-ticket.md.