### PR TITLE
sdk: read Option Explicit and the @OptionStrict annotation per module

### DIFF
--- a/RDCore.SDK/Model/AST/Declarations/ModuleNodeExtensions.cs
+++ b/RDCore.SDK/Model/AST/Declarations/ModuleNodeExtensions.cs
@@ -31,6 +31,22 @@ public static class ModuleNodeExtensions
         return null;
     }
 
+    /// <summary>
+    /// Whether the module declares <c>Option Explicit</c> (<strong>MS-VBAL §5.2.1.3</strong>).
+    /// </summary>
+    public static bool HasOptionExplicit(this ModuleNode module)
+    {
+        foreach (var child in module.Children)
+        {
+            if (child is ModuleOptionDirectiveNode { ModuleOption: ModuleOptions.OptionExplicit })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // AttributeDirectiveNode.Value is the raw parse-tree text; a VB_Name value is a string literal.
     private static string? Unquote(string value)
     {

--- a/RDCore.SDK/Model/Symbols/VBProject/VBDeferredTypeMemberSymbol.cs
+++ b/RDCore.SDK/Model/Symbols/VBProject/VBDeferredTypeMemberSymbol.cs
@@ -11,7 +11,7 @@ public record class VBDeferredTypeMemberSymbol(Uri WorkspaceRoot, Uri ParentUri,
     : UnboundTypedSymbol(WorkspaceRoot, ParentUri, Name, ScopeKind.Module, Kind, VBUnknownType.TypeInfo), IVBDeferrableTypeMember
 {
     public ImmutableHashSet<VBType> CandidateTypes { get; init; } = [];
-    public IVBInferableType WithCandidateType(VBType vbType) => this with { CandidateTypes = [.. CandidateTypes, vbType] };
+    public IVBInferableType WithCandidateType(VBType vbType) => this with { CandidateTypes = CandidateTypes.MergeCandidate(vbType) };
 
     public VBType? DeferredVBType { get; init; }
     public VBDeferredTypeMemberSymbol WithDeferredVBType(VBType vbType) => this with { DeferredVBType = vbType, CandidateTypes = [vbType] };

--- a/RDCore.SDK/Model/Types/Complex/VBDeferredType.cs
+++ b/RDCore.SDK/Model/Types/Complex/VBDeferredType.cs
@@ -104,5 +104,5 @@ public abstract record class VBDeferredType : VBType, IVBDeferrableType
 
     public ImmutableHashSet<VBType> CandidateTypes { get; init; } = [];
 
-    public IVBInferableType WithCandidateType(VBType vbType) => this with { CandidateTypes = [.. CandidateTypes, vbType] };
+    public IVBInferableType WithCandidateType(VBType vbType) => this with { CandidateTypes = CandidateTypes.MergeCandidate(vbType) };
 }

--- a/RDCore.SDK/Model/Types/Complex/VBInferableTypeExtensions.cs
+++ b/RDCore.SDK/Model/Types/Complex/VBInferableTypeExtensions.cs
@@ -1,0 +1,56 @@
+﻿using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Abstract;
+using System.Collections.Immutable;
+
+namespace RDCore.SDK.Model.Types.Complex;
+
+/// <summary>
+/// The candidate-type merge and resolution rules an <see cref="IVBInferableType"/> follows, per its
+/// own static-semantics note (<see cref="IVBInferableType"/> xmldoc remarks).
+/// </summary>
+public static class IVBInferableTypeExtensions
+{
+    /// <summary>
+    /// Resolves the single data type <paramref name="inferable"/>'s candidates currently agree on, or
+    /// <c>null</c> when they don't agree on one yet.
+    /// </summary>
+    /// <remarks>
+    /// A lone candidate resolves to itself. Two or more resolve to <c>Variant</c> when every candidate
+    /// is a plain value type (numeric, <c>String</c>, <c>Boolean</c>, …) — never when one of them is
+    /// <c>Object</c> or a class-ish type (<see cref="IVBMemberOwnerType"/>): those don't blend into a
+    /// <c>Variant</c> guess, and what they <em>do</em> resolve to isn't decided yet (the algorithm's
+    /// own doc trails into "TODO continue this" at exactly this point) — such a set currently resolves
+    /// to <c>null</c>, same as no candidates at all.
+    /// </remarks>
+    public static VBType? Resolve(this IVBInferableType inferable) => inferable.CandidateTypes.Count switch
+    {
+        0 => null,
+        1 => inferable.CandidateTypes.Single(),
+        _ => inferable.CandidateTypes.All(IsPlainValueType) ? VBVariantType.TypeInfo : null,
+    };
+
+    /// <summary>
+    /// Adds <paramref name="vbType"/> as a new candidate, applying the widening / merge rules a newly
+    /// found candidate goes through before joining the set.
+    /// </summary>
+    /// <remarks>
+    /// An integral candidate (<see cref="IIntegralNumericType"/> — <c>Byte</c>/<c>Integer</c>/
+    /// <c>Long</c>/<c>LongLong</c>) widens to <see cref="VBLongType"/>; a floating-point candidate
+    /// (<see cref="IFloatingPointNumericType"/>) widens to <see cref="VBDoubleType"/>; a fixed-point
+    /// candidate (<see cref="IFixedPointNumericType"/>) widens to <see cref="VBCurrencyType"/> — so
+    /// differently-sized numeric candidates bucket together instead of manufacturing spurious
+    /// conflicts. A candidate that is itself inferable contributes its own candidate set (already
+    /// widened) rather than joining as one opaque entry.
+    /// </remarks>
+    public static ImmutableHashSet<VBType> MergeCandidate(this ImmutableHashSet<VBType> candidates, VBType vbType) => vbType switch
+    {
+        IVBInferableType inferable => candidates.Union(inferable.CandidateTypes),
+        IIntegralNumericType => candidates.Add(VBLongType.TypeInfo),
+        IFloatingPointNumericType => candidates.Add(VBDoubleType.TypeInfo),
+        IFixedPointNumericType => candidates.Add(VBCurrencyType.TypeInfo),
+        _ => candidates.Add(vbType),
+    };
+
+    private static bool IsPlainValueType(VBType type) => type is not (VBObjectType or IVBMemberOwnerType or IVBInferableType);
+}

--- a/RDCore.SDK/Model/Types/Complex/VBStdModuleType.cs
+++ b/RDCore.SDK/Model/Types/Complex/VBStdModuleType.cs
@@ -23,7 +23,13 @@ public record class VBStdModuleType(string Name, bool IsHidden = false) : VBType
     /// <param name="name">The <em>identifier name</em> of the module.</param>
     /// <param name="members">The member definition symbols under this module type.</param>
     /// <param name="isHidden"><c>true</c> if the module type is hidden.</param>
-    public VBStdModuleType(string name, IEnumerable<VBTypeMemberSymbol>? members = null, bool isHidden = false)
+    /// <remarks>
+    /// <paramref name="members"/> has no default: with one it collides with the primary constructor's
+    /// <c>(Name, IsHidden = false)</c> for a call site giving only <paramref name="name"/> — both
+    /// would be equally applicable, and the call would not compile (<c>CS0121</c>). Requiring
+    /// <paramref name="members"/> keeps every arity unambiguous.
+    /// </remarks>
+    public VBStdModuleType(string name, IEnumerable<VBTypeMemberSymbol>? members, bool isHidden = false)
         : this(name, isHidden)
     {
         Members = [.. members ?? []];

--- a/RDCore.SDK/Workspace/ModuleAnnotations.cs
+++ b/RDCore.SDK/Workspace/ModuleAnnotations.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.RegularExpressions;
+
+namespace RDCore.SDK.Workspace;
+
+/// <summary>
+/// Reads RD-VBA-only <c>'@AnnotationName</c> comment annotations off a module's raw source — the
+/// legacy-Rubberduck-style syntax the grammar already recognises (<c>annotationList</c> /
+/// <c>annotation</c> / <c>annotationName</c>), read here as plain text rather than off the AST.
+/// </summary>
+/// <remarks>
+/// This is a first cut: a source-text scan, not a parser-built <c>AnnotationTriviaNode</c> — the
+/// grammar rule exists, but nothing yet builds or attaches the node it would produce, and a general
+/// annotation-to-AST wiring is a bigger, cross-cutting change (annotations nest inside
+/// <c>endOfStatement</c>, reachable from nearly every rule). A real, <em>supported</em> grammar-level
+/// <c>Option Strict</c> token is future work; for now the annotation is a comment as far as MS-VBA (or
+/// any real VBA host) is concerned — a workspace stays import/export-compatible with the VBIDE.
+/// </remarks>
+public static partial class ModuleAnnotations
+{
+    /// <summary>
+    /// Whether <paramref name="source"/> carries an <c>'@OptionStrict</c> annotation anywhere in the
+    /// module. <c>false</c> when there is no source to inspect.
+    /// </summary>
+    /// <param name="source">The raw module source, or <c>null</c> when it could not be read.</param>
+    /// <remarks>
+    /// <c>Option Strict</c> is not an MS-VBAL directive — it is RD-VBA's own dial for turning select
+    /// semantic flags that stay legal under plain <c>Option Explicit</c> into compile errors (see
+    /// <c>VBCompileErrorId.ForbiddenWithOptionStrict</c>), the same role a real <c>Option Strict</c>
+    /// statement line is reserved for (<c>ModuleOptions.OptionStrict</c>) once one ships.
+    /// </remarks>
+    public static bool HasOptionStrict(string? source)
+        => !string.IsNullOrEmpty(source) && OptionStrictAnnotation().IsMatch(source);
+
+    // any comment line carrying the @OptionStrict annotation — possibly alongside others on the same
+    // '@... line (the grammar allows one leading ' with several @name groups). Not scoped to a single
+    // bare annotation: matching the word anywhere after the comment marker is enough for a first cut.
+    [GeneratedRegex(@"^[ \t]*'.*@OptionStrict\b", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex OptionStrictAnnotation();
+}

--- a/RDCore.SDK/Workspace/ModuleAnnotations.cs
+++ b/RDCore.SDK/Workspace/ModuleAnnotations.cs
@@ -14,6 +14,17 @@ namespace RDCore.SDK.Workspace;
 /// <c>endOfStatement</c>, reachable from nearly every rule). A real, <em>supported</em> grammar-level
 /// <c>Option Strict</c> token is future work; for now the annotation is a comment as far as MS-VBA (or
 /// any real VBA host) is concerned — a workspace stays import/export-compatible with the VBIDE.
+/// <para>
+/// 📌 A static class hard-coding one annotation's name does not scale — the annotation vocabulary is
+/// open-ended by design (an extension's shape is "annotation-semantics provider + analyzers + …", e.g.
+/// the planned <c>RDCore.UnitTesting</c> extension owning <c>@TestMethod</c>, or the planned
+/// <c>RDCore.DimensionalAnalysis</c> extension owning <c>@Unit</c>), and nothing here should force an
+/// extension to modify the SDK to claim an annotation name. <c>Option Strict</c> is core-owned, not
+/// extension-owned, so this type is fine as the one-off it is <em>today</em> — but once a real
+/// annotation-semantics-provider mechanism exists, this should very likely become one of its
+/// consumers instead of staying a bespoke regex. Noted, not a blocker:
+/// <c>C:\Dev\Claude\rdcore-annotation-semantic-provider-ticket.md</c>.
+/// </para>
 /// </remarks>
 public static partial class ModuleAnnotations
 {

--- a/RDCore.Tests/Model/Types/VBInferableTypeExtensionsTests.cs
+++ b/RDCore.Tests/Model/Types/VBInferableTypeExtensionsTests.cs
@@ -91,7 +91,7 @@ public sealed class VBInferableTypeExtensionsTests
     {
         var inferable = Deferred()
             .WithCandidateType(VBLongType.TypeInfo)
-            .WithCandidateType(new VBStdModuleType("SomeModule", false));
+            .WithCandidateType(new VBStdModuleType("SomeModule"));
 
         Assert.IsNull(inferable.Resolve());
     }

--- a/RDCore.Tests/Model/Types/VBInferableTypeExtensionsTests.cs
+++ b/RDCore.Tests/Model/Types/VBInferableTypeExtensionsTests.cs
@@ -1,0 +1,112 @@
+﻿using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Abstract;
+using RDCore.SDK.Model.Types.Complex;
+
+namespace RDCore.Tests.Model.Types;
+
+[TestClass]
+public sealed class VBInferableTypeExtensionsTests
+{
+    private static VBDeferredModuleType Deferred() => new("Widget", new Uri("file:///c:/ws/#Widget"));
+
+    [TestMethod]
+    public void Resolve_Null_WhenThereAreNoCandidates()
+        => Assert.IsNull(Deferred().Resolve());
+
+    [TestMethod]
+    public void Resolve_TheCandidate_WhenThereIsOnlyOne()
+    {
+        var inferable = Deferred().WithCandidateType(VBStringType.TypeInfo);
+
+        Assert.AreEqual(VBStringType.TypeInfo, inferable.Resolve());
+    }
+
+    [TestMethod]
+    [DataRow(typeof(VBByteType))]
+    [DataRow(typeof(VBIntegerType))]
+    [DataRow(typeof(VBLongType))]
+    [DataRow(typeof(VBLongLongType))]
+    public void WithCandidateType_WidensAnyIntegralCandidate_ToLong(Type integralType)
+    {
+        var candidate = (VBType)integralType.GetProperty("TypeInfo")!.GetValue(null)!;
+
+        var inferable = Deferred().WithCandidateType(candidate);
+
+        Assert.AreEqual(VBLongType.TypeInfo, inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void WithCandidateType_BucketsDifferentlySizedIntegralCandidates_Together()
+    {
+        // Byte then Integer then Long: all widen to Long, so there is still only one candidate.
+        var inferable = Deferred()
+            .WithCandidateType(VBByteType.TypeInfo)
+            .WithCandidateType(VBIntegerType.TypeInfo)
+            .WithCandidateType(VBLongType.TypeInfo);
+
+        Assert.AreEqual(VBLongType.TypeInfo, inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void WithCandidateType_WidensAFloatingPointCandidate_ToDouble()
+    {
+        var inferable = Deferred().WithCandidateType(VBSingleType.TypeInfo);
+
+        Assert.AreEqual(VBDoubleType.TypeInfo, inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void WithCandidateType_WidensAFixedPointCandidate_ToCurrency()
+    {
+        // Currency is both the fixed-point candidate and its own widened bucket.
+        var inferable = Deferred().WithCandidateType(VBCurrencyType.TypeInfo);
+
+        Assert.AreEqual(VBCurrencyType.TypeInfo, inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void Resolve_Variant_WhenMultiplePlainValueCandidatesConflict()
+    {
+        var inferable = Deferred()
+            .WithCandidateType(VBLongType.TypeInfo)
+            .WithCandidateType(VBStringType.TypeInfo);
+
+        Assert.AreEqual(VBVariantType.TypeInfo, inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void Resolve_Null_WhenAnObjectCandidateConflictsWithAnother()
+    {
+        // an Object candidate never blends into a Variant guess with another candidate - what it
+        // resolves to instead isn't decided yet (the algorithm's own note stops here).
+        var inferable = Deferred()
+            .WithCandidateType(VBLongType.TypeInfo)
+            .WithCandidateType(VBObjectType.TypeInfo);
+
+        Assert.IsNull(inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void Resolve_Null_WhenAMemberOwnerCandidateConflictsWithAnother()
+    {
+        var inferable = Deferred()
+            .WithCandidateType(VBLongType.TypeInfo)
+            .WithCandidateType(new VBStdModuleType("SomeModule", false));
+
+        Assert.IsNull(inferable.Resolve());
+    }
+
+    [TestMethod]
+    public void Resolve_TheSoleObjectCandidate_WhenItIsTheOnlyOne()
+        => Assert.AreEqual(VBObjectType.TypeInfo, Deferred().WithCandidateType(VBObjectType.TypeInfo).Resolve());
+
+    [TestMethod]
+    public void WithCandidateType_MergesAnotherInferableTypesCandidates_InsteadOfAddingItOpaquely()
+    {
+        var other = Deferred().WithCandidateType(VBStringType.TypeInfo);
+
+        var inferable = Deferred().WithCandidateType(VBLongType.TypeInfo).WithCandidateType((VBDeferredModuleType)other);
+
+        Assert.AreEqual(VBVariantType.TypeInfo, inferable.Resolve());
+    }
+}

--- a/RDCore.Tests/Parser/ModuleNodeExtensionsTests.cs
+++ b/RDCore.Tests/Parser/ModuleNodeExtensionsTests.cs
@@ -37,4 +37,20 @@ public sealed class ModuleNodeExtensionsTests
 
         Assert.AreEqual("a\"b", module.GetDeclaredName());
     }
+
+    [TestMethod]
+    public void HasOptionExplicit_True_WhenModuleDeclaresIt()
+    {
+        var module = Parse("Attribute VB_Name = \"M1\"\r\nOption Explicit\r\nPublic X As Long\r\n");
+
+        Assert.IsTrue(module.HasOptionExplicit());
+    }
+
+    [TestMethod]
+    public void HasOptionExplicit_False_WhenModuleDoesNotDeclareIt()
+    {
+        var module = Parse("Attribute VB_Name = \"M1\"\r\nPublic X As Long\r\n");
+
+        Assert.IsFalse(module.HasOptionExplicit());
+    }
 }

--- a/RDCore.Tests/Workspace/ModuleAnnotationsTests.cs
+++ b/RDCore.Tests/Workspace/ModuleAnnotationsTests.cs
@@ -1,0 +1,30 @@
+﻿using RDCore.SDK.Workspace;
+
+namespace RDCore.Tests.Workspace;
+
+[TestClass]
+public sealed class ModuleAnnotationsTests
+{
+    [TestMethod]
+    [DataRow("'@OptionStrict\r\nAttribute VB_Name = \"M1\"\r\n")]
+    [DataRow("Attribute VB_Name = \"M1\"\r\n'@OptionStrict\r\nOption Explicit\r\n")] // anywhere in the module
+    [DataRow("'@optionstrict\r\n")]                              // annotation names are case-insensitive
+    [DataRow("  '@OptionStrict\r\n")]                            // leading whitespace before the comment
+    [DataRow("'@Folder(\"Foo\") @OptionStrict\r\n")]              // alongside another annotation
+    [DataRow("'@OptionStrict: a note about why\r\n")]             // trailing plain-comment tail
+    public void HasOptionStrict_True_WhenSourceCarriesTheAnnotation(string source)
+        => Assert.IsTrue(ModuleAnnotations.HasOptionStrict(source));
+
+    [TestMethod]
+    [DataRow("Attribute VB_Name = \"M1\"\r\nOption Explicit\r\n")]
+    [DataRow("'@Folder(\"Foo\")\r\n")]
+    [DataRow("Dim s As String\r\ns = \"'@OptionStrict\"\r\n")]     // not a comment - a string literal
+    public void HasOptionStrict_False_WhenSourceHasNoAnnotation(string source)
+        => Assert.IsFalse(ModuleAnnotations.HasOptionStrict(source));
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    public void HasOptionStrict_False_WhenThereIsNoSource(string? source)
+        => Assert.IsFalse(ModuleAnnotations.HasOptionStrict(source));
+}


### PR DESCRIPTION
Prerequisite ahead of #175, flagged reviewing #176: nothing consumed Option Explicit (parsed onto ModuleOptionDirectiveNode, never read) or gated the deferred-symbol/intent-driven-development behaviour the author wants layered on top of it.

ModuleNodeExtensions.HasOptionExplicit mirrors GetDeclaredName - a scan over ModuleNode.Children for the directive, already on the AST.

Option Strict is not MS-VBAL; it stays a '@OptionStrict comment annotation for now; a real grammar-level token is future work. The grammar's annotationList rule already recognises the '@... comment syntax, but nothing builds or attaches the AnnotationTriviaNode it would produce - wiring that generically is a bigger, cross-cutting change (annotations nest inside endOfStatement, reachable from nearly every rule). ModuleAnnotations.HasOptionStrict reads it straight off the raw source instead, same approach as ModuleHeader.IsClassModule's VERSION-header regex - a workspace stays import/export-compatible with the VBIDE since a real VBA host just sees a comment.