### PR TITLE
sdk: StaticEvaluationContext + ModuleDirectives scope carrier (#175)

### DIFF
--- a/RDCore.SDK/Model/Symbols/LexicalScope.cs
+++ b/RDCore.SDK/Model/Symbols/LexicalScope.cs
@@ -35,11 +35,16 @@ public sealed class LexicalScope
     /// (a field and a procedure that collide, two <c>Dim</c>s of one name) keeps every declaration —
     /// reporting the <em>ambiguous name</em> is the caller's concern.
     /// </param>
-    public LexicalScope(Uri uri, LexicalScopeKind kind, LexicalScope? parent, IEnumerable<Symbol> declarations)
+    /// <param name="directives">
+    /// The declaring module's <see cref="ModuleDirectives"/> — <c>null</c> for every tier except the
+    /// module scope itself, which carries its <see cref="VBModuleSymbol.Directives"/>.
+    /// </param>
+    public LexicalScope(Uri uri, LexicalScopeKind kind, LexicalScope? parent, IEnumerable<Symbol> declarations, ModuleDirectives? directives = null)
     {
         Uri = uri;
         Kind = kind;
         Parent = parent;
+        Directives = directives;
         _declarations = declarations.ToLookup(symbol => symbol.Name, StringComparer.OrdinalIgnoreCase);
     }
 
@@ -51,6 +56,16 @@ public sealed class LexicalScope
 
     /// <summary>The enclosing scope, or <c>null</c> for the global scope.</summary>
     public LexicalScope? Parent { get; }
+
+    /// <summary>The declaring module's directives, for the module scope itself; <c>null</c> elsewhere.</summary>
+    public ModuleDirectives? Directives { get; }
+
+    /// <summary>
+    /// The <see cref="ModuleDirectives"/> of the module enclosing this scope — itself, if this
+    /// <em>is</em> the module scope, otherwise the nearest ancestor that carries them. <c>null</c>
+    /// when no enclosing module scope exists (the global or project scope, reached directly).
+    /// </summary>
+    public ModuleDirectives? EnclosingModuleDirectives() => SelfAndAncestors().Select(scope => scope.Directives).FirstOrDefault(directives => directives is not null);
 
     /// <summary>
     /// The symbols this scope declares directly under <paramref name="name"/>, matched

--- a/RDCore.SDK/Model/Symbols/ModuleDirectives.cs
+++ b/RDCore.SDK/Model/Symbols/ModuleDirectives.cs
@@ -1,0 +1,29 @@
+namespace RDCore.SDK.Model.Symbols;
+
+/// <summary>
+/// The resolved module-level directives a <see cref="VBModuleSymbol"/> was declared under — the
+/// <c>Option ...</c> statements (<strong>MS-VBAL §5.2.1</strong>) and <c>Attribute VB_...</c>
+/// declarations (<strong>MS-VBAL §4.2</strong>) a static-semantics pass needs to know about, plus
+/// RD-VBA's own annotation-driven dials (<c>Option Strict</c>).
+/// </summary>
+/// <remarks>
+/// Named <em>Directives</em>, not <em>Options</em>: MS-VBAL's own <c>Option</c> statements are only
+/// one source feeding this — <c>Attribute</c> declarations (<c>VB_Name</c>, <c>VB_PredeclaredId</c>,
+/// …) and RD-VBA annotations belong here too, as this grows one property at a time. A consumer that
+/// needs a new directive adds a property to this record; nothing that carries a
+/// <see cref="ModuleDirectives"/> — <see cref="VBModuleSymbol"/>, <see cref="LexicalScope"/>,
+/// <c>StaticEvaluationContext</c> — ever changes shape because of it.
+/// </remarks>
+/// <param name="Explicit">
+/// Whether the module declares <c>Option Explicit</c> (<strong>MS-VBAL §5.2.1.3</strong>) — an
+/// unresolved <c>SimpleName</c> is a compile error under this module, not a deferred/inferred type.
+/// </param>
+/// <param name="Strict">
+/// Whether the module carries RD-VBA's <c>'@OptionStrict</c> annotation — turns select semantic
+/// flags that stay legal under plain <c>Option Explicit</c> into compile errors.
+/// </param>
+public readonly record struct ModuleDirectives(bool Explicit = false, bool Strict = false)
+{
+    /// <summary>The directives of a module that declares none of them explicitly.</summary>
+    public static readonly ModuleDirectives None = new();
+}

--- a/RDCore.SDK/Model/Symbols/ScopeTreeBuilder.cs
+++ b/RDCore.SDK/Model/Symbols/ScopeTreeBuilder.cs
@@ -116,7 +116,8 @@ public static class ScopeTreeBuilder
         var moduleScopes = new Dictionary<string, LexicalScope>(StringComparer.Ordinal);
         foreach (var (uri, symbol) in modules)
         {
-            var scope = new LexicalScope(symbol.Uri, LexicalScopeKind.Module, moduleParent, moduleDeclarations[uri]);
+            var directives = symbol is VBModuleSymbol module ? module.Directives : ModuleDirectives.None;
+            var scope = new LexicalScope(symbol.Uri, LexicalScopeKind.Module, moduleParent, moduleDeclarations[uri], directives);
             moduleScopes[uri] = scope;
             scopeByUri[uri] = scope;
             MapDeclarationsToScope(scopeByUri, moduleDeclarations[uri], scope);

--- a/RDCore.SDK/Model/Symbols/VBModuleSymbol.cs
+++ b/RDCore.SDK/Model/Symbols/VBModuleSymbol.cs
@@ -12,4 +12,8 @@ namespace RDCore.SDK.Model.Symbols;
 /// <param name="Scope">The allocation scope of the symbol.</param>
 /// <param name="Kind">A <c>SymbolKind</c> (extended, LSP-compliant) metadata value describing the kind of symbol.</param>
 public abstract record class VBModuleSymbol(Uri WorkspaceRoot, Uri ParentUri, string Name, ScopeKind Scope, SymbolKindExt Kind)
-    : Symbol(WorkspaceRoot, ParentUri, Name, Scope, Kind) { }
+    : Symbol(WorkspaceRoot, ParentUri, Name, Scope, Kind)
+{
+    /// <summary>The module-level directives this module was declared under.</summary>
+    public ModuleDirectives Directives { get; init; } = ModuleDirectives.None;
+}

--- a/RDCore.SDK/Semantics/Static/Abstract/BinaryArithmeticOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Abstract/BinaryArithmeticOperatorStaticSemantics.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 
 namespace RDCore.SDK.Semantics.Static.Abstract;
 
@@ -13,21 +12,21 @@ public abstract record class BinaryArithmeticOperatorStaticSemantics() : StaticS
     /// <summary>
     /// Determines a static <c>VBType</c> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
-    public override StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes)
-        => DetermineOperatorStaticType(resolver, expression, operandDeclaredTypes[0], operandDeclaredTypes[1]);
+    public override StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes)
+        => DetermineOperatorStaticType(context, expression, operandDeclaredTypes[0], operandDeclaredTypes[1]);
 
     /// <summary>
     /// MS-VBAL 5.6.9.3 Arithmetic Operators (static semantics) 
     /// The operator has the declared type returned by this method, based on the declared type of its operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the LHS operand.</param>
     /// <param name="rhs">The declared type of the RHS operand.</param>
-    protected virtual StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs)
+    protected virtual StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs)
         => lhs switch
         {
             VBByteType when rhs is VBByteType => VBByteType.TypeInfo,

--- a/RDCore.SDK/Semantics/Static/Abstract/BinaryLogicalOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Abstract/BinaryLogicalOperatorStaticSemantics.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 
 namespace RDCore.SDK.Semantics.Static.Abstract;
 
@@ -14,11 +13,11 @@ public record class BinaryLogicalOperatorStaticSemantics : StaticSemantics, ISta
     /// MS-VBAL 5.6.9.3 Arithmetic Operators (static semantics) 
     /// The operator has the declared type returned by this method, based on the declared type of its operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of the operands.</param>
     public override StaticSemanticsEvaluationResult DetermineDeclaredType(
-        ISymbolResolver resolver,
+        StaticEvaluationContext context,
         ExpressionNode expression, 
         params VBType[] operandDeclaredTypes)
         => DetermineOperatorStaticType(expression, operandDeclaredTypes[(int)InputIndex.BinaryLeftOperand], operandDeclaredTypes[(int)InputIndex.BinaryRightOperand]);

--- a/RDCore.SDK/Semantics/Static/Abstract/BinaryRelationalOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Abstract/BinaryRelationalOperatorStaticSemantics.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 
 namespace RDCore.SDK.Semantics.Static.Abstract;
 
@@ -14,11 +13,11 @@ public record class BinaryRelationalOperatorStaticSemantics : StaticSemantics, I
     /// MS-VBAL 5.6.9.5 Relational Operators (static semantics) 
     /// The operator has the declared type returned by this method, based on the declared type of its operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of the operands.</param>
     public override StaticSemanticsEvaluationResult DetermineDeclaredType(
-        ISymbolResolver resolver,
+        StaticEvaluationContext context,
         ExpressionNode expression,
         params VBType[] operandDeclaredTypes)
         => DetermineOperatorStaticType(expression, operandDeclaredTypes[(int)InputIndex.BinaryLeftOperand], operandDeclaredTypes[(int)InputIndex.BinaryRightOperand]);

--- a/RDCore.SDK/Semantics/Static/Abstract/StaticEvaluationContext.cs
+++ b/RDCore.SDK/Semantics/Static/Abstract/StaticEvaluationContext.cs
@@ -1,0 +1,20 @@
+using RDCore.SDK.Model.Symbols;
+using RDCore.SDK.Runtime.Abstract.Execution;
+
+namespace RDCore.SDK.Semantics.Static.Abstract;
+
+/// <summary>
+/// The compile-time context an <see cref="IStaticSemantics"/> rule evaluates an expression against:
+/// the name-resolution service, and the <see cref="LexicalScope"/> a <c>SimpleName</c> or
+/// <c>MemberAccess</c> expression resolves from (<strong>RD-VBAL §2.3.1.2</strong>).
+/// </summary>
+/// <remarks>
+/// Deliberately just these two. A rule that needs a module-level fact — <c>Option Explicit</c>,
+/// <c>Option Compare</c>, whatever MS-VBAL directive comes next — reads it off
+/// <see cref="LexicalScope.EnclosingModuleDirectives"/> through <see cref="Scope"/>, rather than this
+/// record growing a parameter for it: <see cref="ModuleDirectives"/> is where that kind of fact
+/// belongs, so this signature never has to change again to carry one.
+/// </remarks>
+/// <param name="Resolver">Resolves identifier names to symbols and reads their bound values.</param>
+/// <param name="Scope">The scope the expression being evaluated is lexically found in.</param>
+public readonly record struct StaticEvaluationContext(ISymbolResolver Resolver, LexicalScope Scope);

--- a/RDCore.SDK/Semantics/Static/Abstract/StaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Abstract/StaticSemantics.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 
 namespace RDCore.SDK.Semantics.Static.Abstract;
 
@@ -52,13 +51,13 @@ public interface IStaticSemantics
     /// <summary>
     /// Determines a static <c>VBType</c> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes);
+    StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes);
 }
 
 /// <summary>
@@ -69,13 +68,13 @@ public abstract record class StaticSemantics() : IStaticSemantics
     /// <summary>
     /// Determines a static <c>VBType</c> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    public abstract StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes);
+    public abstract StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes);
 
     /// <summary>
     /// Gets the error metadata for a <em>type mismatch</em> compile-time error.

--- a/RDCore.SDK/Semantics/Static/Abstract/UnaryArithmeticOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Abstract/UnaryArithmeticOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 
 namespace RDCore.SDK.Semantics.Static.Abstract;
 
@@ -17,14 +16,14 @@ public record class UnaryArithmeticOperatorStaticSemantics : StaticSemantics, IS
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    public override StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes)
-        => DetermineOperatorStaticType(resolver, expression, operandDeclaredTypes[(int)InputIndex.UnaryOperand]);
+    public override StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes)
+        => DetermineOperatorStaticType(context, expression, operandDeclaredTypes[(int)InputIndex.UnaryOperand]);
 
     /// <summary>
     /// MS-VBAL 5.6.9.3 Arithmetic Operators (static semantics) 
@@ -32,7 +31,7 @@ public record class UnaryArithmeticOperatorStaticSemantics : StaticSemantics, IS
     /// </summary>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operand">The declared type of the operand.</param>
-    protected virtual StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType operand)  
+    protected virtual StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType operand)  
         => operand switch
         {
             VBByteType => VBByteType.TypeInfo,

--- a/RDCore.SDK/Semantics/Static/Expressions/LiteralExpressionStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Expressions/LiteralExpressionStaticSemantics.cs
@@ -1,6 +1,5 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Expressions;
@@ -14,9 +13,9 @@ public record class LiteralExpressionStaticSemantics : IStaticSemantics
     /// MS-VBAL 5.6.5 Literal Expressions (static semantics) 
     /// The declared type of a <em>literal expression</em> is that of the specified token.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of the operands.</param>
-    public StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes) 
+    public StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes) 
         => StaticSemanticsEvaluationResult.Success(operandDeclaredTypes[(int)InputIndex.UnaryOperand]);
 }

--- a/RDCore.SDK/Semantics/Static/LetCoercionStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/LetCoercionStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Model.Types.Complex;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static;
@@ -15,7 +14,7 @@ public record class LetCoercionStaticSemantics : StaticSemantics
     private static readonly Lazy<LetCoercionStaticSemantics> _instance = new(() => new(), LazyThreadSafetyMode.PublicationOnly);
     public static IStaticSemantics Instance => _instance.Value;
 
-    public override StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes)
+    public override StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes)
     {
         var destinationType = operandDeclaredTypes[(int)InputIndex.CoercionDestinationType];
         return !IsLetCoercionInvalid(operandDeclaredTypes[(int)InputIndex.CoercionSourceValue], destinationType) 

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryAdditionOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryAdditionOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,17 +14,17 @@ public sealed record class BinaryAdditionOperatorStaticSemantics() : BinaryArith
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the <em>left-hand side</em> (LHS) operand involved in the evaluation.</param>
     /// <param name="rhs">The declared type of the <em>right-hand side</em> (RHS) operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs) 
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs) 
         => lhs switch
         {
             VBStringType when rhs is VBStringType => StaticSemanticsEvaluationResult.Success(VBStringType.TypeInfo),
-            _ => base.DetermineOperatorStaticType(resolver, expression, lhs, rhs)
+            _ => base.DetermineOperatorStaticType(context, expression, lhs, rhs)
         };
 }

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryConcatOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryConcatOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,13 +14,13 @@ public record class BinaryConcatOperatorStaticSemantics : StaticSemantics
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    public override StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes)
+    public override StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes)
     {
         var lhs = operandDeclaredTypes[(int)InputIndex.BinaryLeftOperand];
         var rhs = operandDeclaredTypes[(int)InputIndex.BinaryRightOperand];

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryDivisionOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryDivisionOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,14 +14,14 @@ public sealed record class BinaryDivisionOperatorStaticSemantics : BinaryArithme
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the <em>left-hand side</em> (LHS) operand involved in the evaluation.</param>
     /// <param name="rhs">The declared type of the <em>right-hand side</em> (RHS) operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs) 
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs) 
         => lhs switch
         {
             VBByteType or VBBooleanType or VBIntegerType or VBLongType or VBLongLongType
@@ -37,6 +36,6 @@ public sealed record class BinaryDivisionOperatorStaticSemantics : BinaryArithme
                 when rhs is VBDoubleType or VBFixedStringType or VBStringType or VBCurrencyType or VBDateType
                 => StaticSemanticsEvaluationResult.Success(VBDoubleType.TypeInfo),
 
-            _ => base.DetermineOperatorStaticType(resolver, expression, lhs, rhs)
+            _ => base.DetermineOperatorStaticType(context, expression, lhs, rhs)
         };
 }

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryExponentOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryExponentOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,20 +14,20 @@ public sealed record class BinaryExponentOperatorStaticSemantics : BinaryArithme
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the <em>left-hand side</em> (LHS) operand involved in the evaluation.</param>
     /// <param name="rhs">The declared type of the <em>right-hand side</em> (RHS) operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs) 
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs) 
         => lhs switch
         {
             VBNumericType or VBFixedStringType or VBStringType or VBDateType
                 when rhs is VBNumericType or VBFixedStringType or VBStringType or VBDateType
                 => StaticSemanticsEvaluationResult.Success(VBDoubleType.TypeInfo),
 
-            _ => base.DetermineOperatorStaticType(resolver, expression, lhs, rhs)
+            _ => base.DetermineOperatorStaticType(context, expression, lhs, rhs)
         };
 }

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryIntegerDivisionOperatorStaticSematics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryIntegerDivisionOperatorStaticSematics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,14 +14,14 @@ public sealed record class BinaryIntegerDivisionOperatorStaticSematics : BinaryA
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the <em>left-hand side</em> (LHS) operand involved in the evaluation.</param>
     /// <param name="rhs">The declared type of the <em>right-hand side</em> (RHS) operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs) 
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs) 
         => lhs switch
         {
             IFloatingPointNumericType or IFixedPointNumericType or VBFixedStringType or VBStringType or VBDateType
@@ -70,6 +69,6 @@ public sealed record class BinaryIntegerDivisionOperatorStaticSematics : BinaryA
                 when rhs is VBDateType 
                     => StaticSemanticsEvaluationResult.Success(VBLongType.TypeInfo),
 
-            _ => base.DetermineOperatorStaticType(resolver, expression, lhs, rhs)
+            _ => base.DetermineOperatorStaticType(context, expression, lhs, rhs)
         };
 }

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryIsRefEqOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryIsRefEqOperatorStaticSemantics.cs
@@ -3,7 +3,6 @@ using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Model.Types.Complex;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -16,13 +15,13 @@ public sealed record class BinaryIsRefEqOperatorStaticSemantics : StaticSemantic
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    public override  StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes)
+    public override  StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes)
     {
         // MS-VBAL: each expression MUST be classified as a value and
         // the declared type of each expression MUST be a specific class, Object, or Variant.

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryLetCoerceOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryLetCoerceOperatorStaticSemantics.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -17,12 +16,12 @@ public sealed record class BinaryLetCoerceOperatorStaticSemantics() : StaticSema
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    public override StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes) 
-        => LetCoercionStaticSemantics.Instance.DetermineDeclaredType(resolver, expression, operandDeclaredTypes);
+    public override StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes) 
+        => LetCoercionStaticSemantics.Instance.DetermineDeclaredType(context, expression, operandDeclaredTypes);
 }

--- a/RDCore.SDK/Semantics/Static/Operators/BinaryMultiplicationOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinaryMultiplicationOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,14 +14,14 @@ public sealed record class BinaryMultiplicationOperatorStaticSemantics : BinaryA
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the <em>left-hand side</em> (LHS) operand involved in the evaluation.</param>
     /// <param name="rhs">The declared type of the <em>right-hand side</em> (RHS) operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs)
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs)
     {
         return lhs switch
         {
@@ -40,7 +39,7 @@ public sealed record class BinaryMultiplicationOperatorStaticSemantics : BinaryA
                 when rhs is VBDateType 
                     => StaticSemanticsEvaluationResult.Success(VBDoubleType.TypeInfo),
         
-            _ => base.DetermineOperatorStaticType(resolver, expression, lhs, rhs)
+            _ => base.DetermineOperatorStaticType(context, expression, lhs, rhs)
         };
     }
 }

--- a/RDCore.SDK/Semantics/Static/Operators/BinarySubtractionOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/BinarySubtractionOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,17 +14,17 @@ public record class BinarySubtractionOperatorStaticSemantics : BinaryArithmeticO
     /// <summary>
     /// Determines a static <see cref="VBType"/> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="lhs">The declared type of the <em>left-hand side</em> (LHS) operand involved in the evaluation.</param>
     /// <param name="rhs">The declared type of the <em>right-hand side</em> (RHS) operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType lhs, VBType rhs) 
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType lhs, VBType rhs) 
         => lhs switch
         {
             VBDateType when rhs is VBDateType => StaticSemanticsEvaluationResult.Success(VBDoubleType.TypeInfo),
-            _ => base.DetermineOperatorStaticType(resolver, expression, lhs, rhs)
+            _ => base.DetermineOperatorStaticType(context, expression, lhs, rhs)
         };
 }

--- a/RDCore.SDK/Semantics/Static/Operators/UnaryLogicalOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/UnaryLogicalOperatorStaticSemantics.cs
@@ -2,7 +2,6 @@
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -15,13 +14,13 @@ public record class UnaryLogicalOperatorStaticSemantics : StaticSemantics
     /// <summary>
     /// Determines a static <c>VBType</c> from specified operands.
     /// </summary>
-    /// <param name="resolver">The static context containing the available static memory space.</param>
+    /// <param name="context">The compile-time context this expression is evaluated against.</param>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operandDeclaredTypes">The declared type of each operand involved in the evaluation.</param>
     /// <returns>
     /// A <see cref="StaticSemanticsEvaluationResult"/> encapsulating the resulting <see cref="VBType"/> if successful, or <see cref="VBCompileErrorInfo"/> error metadata otherwise.
     /// </returns>
-    public override StaticSemanticsEvaluationResult DetermineDeclaredType(ISymbolResolver resolver, ExpressionNode expression, params VBType[] operandDeclaredTypes) 
+    public override StaticSemanticsEvaluationResult DetermineDeclaredType(StaticEvaluationContext context, ExpressionNode expression, params VBType[] operandDeclaredTypes) 
         => operandDeclaredTypes[(int)InputIndex.UnaryOperand] switch
         {
             VBByteType => VBByteType.TypeInfo,

--- a/RDCore.SDK/Semantics/Static/Operators/UnaryNegationOperatorStaticSemantics.cs
+++ b/RDCore.SDK/Semantics/Static/Operators/UnaryNegationOperatorStaticSemantics.cs
@@ -1,7 +1,6 @@
 ﻿using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Semantics.Static.Abstract;
 
 namespace RDCore.SDK.Semantics.Static.Operators;
@@ -17,10 +16,10 @@ public sealed record class UnaryNegationOperatorStaticSemantics : UnaryArithmeti
     /// </summary>
     /// <param name="expression">The <em>expression node</em> being evaluated.</param>
     /// <param name="operand">The declared type of the operand.</param>
-    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(ISymbolResolver resolver, ExpressionNode expression, VBType operand) 
+    protected override StaticSemanticsEvaluationResult DetermineOperatorStaticType(StaticEvaluationContext context, ExpressionNode expression, VBType operand) 
         => operand switch
         {
             VBByteType => StaticSemanticsEvaluationResult.Success(VBIntegerType.TypeInfo),
-            _ => base.DetermineOperatorStaticType(resolver, expression, operand)
+            _ => base.DetermineOperatorStaticType(context, expression, operand)
         };
 }

--- a/RDCore.Tests/Model/Symbols/ScopeTreeBuilderTests.cs
+++ b/RDCore.Tests/Model/Symbols/ScopeTreeBuilderTests.cs
@@ -213,4 +213,33 @@ public sealed class ScopeTreeBuilderTests
         Assert.AreSame(api, tree.ScopeFor(@class.Uri).DeclaredAs("Refresh").Single(), "still an instance member");
         Assert.IsEmpty(tree.ScopeFor(@class.Uri).Parent!.DeclaredAs("Refresh"), "but not surfaced to sibling modules");
     }
+
+    [TestMethod]
+    public void TheModuleScope_CarriesTheModuleSymbolsDirectives()
+    {
+        var module = Module("Mod1") with { Directives = new ModuleDirectives(Explicit: true) };
+
+        var tree = ScopeTreeBuilder.Build([module]);
+
+        Assert.AreEqual(new ModuleDirectives(Explicit: true), tree.ScopeFor(module.Uri).Directives);
+    }
+
+    [TestMethod]
+    public void EnclosingModuleDirectives_WalksUpFromAProcedureScope_ToItsModule()
+    {
+        var module = Module("Mod1") with { Directives = new ModuleDirectives(Explicit: true) };
+        var procedure = Procedure(module.Uri, "DoWork");
+
+        var tree = ScopeTreeBuilder.Build([module, procedure]);
+
+        Assert.AreEqual(new ModuleDirectives(Explicit: true), tree.ScopeFor(procedure.Uri).EnclosingModuleDirectives());
+    }
+
+    [TestMethod]
+    public void EnclosingModuleDirectives_IsNull_OutsideAnyModuleScope()
+    {
+        var tree = ScopeTreeBuilder.Build([]);
+
+        Assert.IsNull(tree.Global.EnclosingModuleDirectives());
+    }
 }

--- a/RDCore.Tests/Semantics/Abstract/StaticSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Abstract/StaticSemanticsTests.cs
@@ -1,5 +1,7 @@
 using NSubstitute;
 using RDCore.SDK.Model.AST.Expressions;
+using RDCore.SDK.Model.Symbols;
+using RDCore.SDK.Model.Symbols.Abstract;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Runtime.Abstract.Execution;
@@ -12,8 +14,10 @@ public abstract class StaticSemanticsTests
     public static void AssertDeterminedDeclaredType(StaticSemantics semantics, VBType[] operandDeclaredTypes, VBType expected)
     {
         var resolver = Substitute.For<ISymbolResolver>();
+        var scope = new LexicalScope(StaticSymbol.GlobalUri, LexicalScopeKind.Global, parent: null, []);
+        var context = new StaticEvaluationContext(resolver, scope);
         var expression = new LiteralExpressionNode(new(TestUri.TestModuleUri().AbsolutePath, [42]), TestLocations.TestLocation, VBUnknownType.TypeInfo.DefaultValue);
-        var result = semantics.DetermineDeclaredType(resolver, expression, operandDeclaredTypes);
+        var result = semantics.DetermineDeclaredType(context, expression, operandDeclaredTypes);
         Assert.AreEqual(expected, result.Result);
     }
 }


### PR DESCRIPTION
IStaticSemantics.DetermineDeclaredType took a bare ISymbolResolver with nowhere to carry the scope a SimpleName/MemberAccess expression needs to resolve from (D4). Replaces it with StaticEvaluationContext(Resolver, Scope) across the whole hierarchy.

Module-level facts a static-semantics rule needs (Option Explicit today, more MS-VBAL directives and Attribute declarations later) live on a new ModuleDirectives record carried by VBModuleSymbol and denormalized onto a module's LexicalScope, reachable via EnclosingModuleDirectives() from any scope nested under it. This keeps StaticEvaluationContext's shape stable as the directive surface grows, instead of the context (or the interface signature) picking up a new parameter every time.