### PR TITLE
runtime: test coverage for arithmetic operators

### DIFF
--- a/RDCore.Runtime/Semantics/Abstract/OperatorRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/Abstract/OperatorRuntimeSemantics.cs
@@ -203,6 +203,10 @@ where TFlags : struct, Enum
 
         if (effectiveTypeResult.Result is VBType effectiveType) // this should be a given
         {
+            // the determined effective type must be in the frame before operand validation and
+            // evaluation run, since both key their own dispatch off frame.EffectiveType.
+            frame = frame with { EffectiveType = effectiveType };
+
             // 2. Validate the operands (let-coercion and overflow checks).
             var validOperands = Enumerable.Range(0, frame.Operands.Length)
                 .Select(index => ValidateOperand(resolver, expression, frame, (InputIndex)index))
@@ -300,14 +304,18 @@ where TFlags : struct, Enum
         var operand = frame[operandIndex];
         Debug.Assert(operand is not VBNullValue);
 
-        return frame.EffectiveType.Equals(operand.TypeInfo)
-            // if the type of the operand is the effective type, the result is the unchanged operand (no coercion occurs).
+        // a Date effective type is computed in Double (MS-VBAL 5.6.9.3 et al.): the operand is
+        // let-coerced to Double even when its own declared type already is Date.
+        var destinationType = frame.EffectiveType is VBDateType ? VBDoubleType.TypeInfo : frame.EffectiveType;
+
+        return destinationType.Equals(operand.TypeInfo)
+            // if the type of the operand is the destination type, the result is the unchanged operand (no coercion occurs).
             ? LetCoercionResult.Success(operand)
             : LetCoercionSemanticsProvider.EvaluateLetCoercionSemantics(resolver, expression, new() {
                 NodeId = expression.Identity,
                 OperandIndex = operandIndex,
                 SourceValue = operand,
-                DestinationTypeDesc = new VBTypeDescValue(frame.EffectiveType),
+                DestinationTypeDesc = new VBTypeDescValue(destinationType),
             });
     }
 }

--- a/RDCore.Runtime/Semantics/Operators/Arithmetic/BinaryIntegerDivisionOperatorRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/Operators/Arithmetic/BinaryIntegerDivisionOperatorRuntimeSemantics.cs
@@ -30,7 +30,7 @@ public record class BinaryIntegerDivisionOperatorRuntimeSemantics(
         VBBinaryOperatorExpressionNode expression, 
         OperatorEvaluationFrame frame) 
     {
-        var rhs = frame[InputIndex.BinaryLeftOperand].TypeInfo;
+        var rhs = frame[InputIndex.BinaryRightOperand].TypeInfo;
         return frame[InputIndex.BinaryLeftOperand].TypeInfo switch
         {
             VBByteType when rhs is VBEmptyType 

--- a/RDCore.Runtime/Semantics/Operators/BinaryArithmeticOperatorRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/Operators/BinaryArithmeticOperatorRuntimeSemantics.cs
@@ -138,11 +138,11 @@ public abstract record class BinaryArithmeticOperatorRuntimeSemantics(
             IIntegralNumericType or IFloatingPointNumericType or VBStringType or VBEmptyType when rhsType is VBCurrencyType => VBCurrencyType.TypeInfo,
 
             // date values are let-coerced to VBDoubleValue
-            VBDateType when rhsType is IIntegralNumericType or IFloatingPointNumericType or VBStringType or VBDateType or VBEmptyType => VBDateType.TypeInfo,
-            IIntegralNumericType or IFloatingPointNumericType or VBStringType or VBDateType or VBEmptyType when rhsType is VBDateType => VBDateType.TypeInfo,
+            VBDateType when rhsType is IIntegralNumericType or IFloatingPointNumericType or VBCurrencyType or VBStringType or VBDateType or VBEmptyType => VBDateType.TypeInfo,
+            IIntegralNumericType or IFloatingPointNumericType or VBCurrencyType or VBStringType or VBDateType or VBEmptyType when rhsType is VBDateType => VBDateType.TypeInfo,
 
-            VBDecimalType when rhsType is INumericType or VBCurrencyType or VBStringType or VBEmptyType => VBCurrencyType.TypeInfo,
-            INumericType or VBStringType or VBEmptyType when rhsType is VBCurrencyType => VBCurrencyType.TypeInfo,
+            VBDecimalType when rhsType is INumericType or VBStringType or VBDateType or VBEmptyType => VBDecimalType.TypeInfo,
+            INumericType or VBStringType or VBDateType or VBEmptyType when rhsType is VBDecimalType => VBDecimalType.TypeInfo,
 
             VBNullType when rhsType is INumericType or VBStringType or VBDateType or VBEmptyType or VBNullType => VBNullType.TypeInfo,
             INumericType or VBStringType or VBDateType or VBEmptyType or VBNullType when rhsType is VBNullType => VBNullType.TypeInfo,

--- a/RDCore.Tests/Semantics/Runtime/BinaryArithmeticOperatorEffectiveTypeTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/BinaryArithmeticOperatorEffectiveTypeTests.cs
@@ -1,0 +1,72 @@
+using RDCore.Runtime.Semantics.Operators.Arithmetic;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Abstract;
+
+namespace RDCore.Tests.Semantics.Runtime;
+
+/// <summary>
+/// Characterization matrix for the general binary arithmetic effective-type table shared by every
+/// arithmetic operator that has no operator-specific override (MS-VBAL §5.6.9.3, runtime semantics).
+/// </summary>
+[TestClass]
+[TestCategory("RD-VBAL §5.0.2.1 Operator Evaluation")]
+[TestCategory("MS-VBAL 5.6.9.3 Arithmetic Operators (runtime semantics)")]
+public sealed class BinaryArithmeticOperatorEffectiveTypeTests : OperatorArithmeticRuntimeSemanticsTests
+{
+    // subtraction has no operator-specific override, so it exercises the shared base table verbatim.
+    private static BinarySubtractionOperatorRuntimeSematics Op() => new(FakeProvider(), Formatter());
+
+    [TestMethod]
+    public void ResolvesEffectiveValueType_AcrossTheOperandGrid()
+    {
+        VBType b = VBByteType.TypeInfo, boo = VBBooleanType.TypeInfo, i = VBIntegerType.TypeInfo,
+            l = VBLongType.TypeInfo, ll = VBLongLongType.TypeInfo, s = VBSingleType.TypeInfo,
+            d = VBDoubleType.TypeInfo, cur = VBCurrencyType.TypeInfo, dec = VBDecimalType.TypeInfo,
+            dt = VBDateType.TypeInfo, str = VBStringType.TypeInfo, e = VBEmptyType.TypeInfo,
+            n = VBNullType.TypeInfo;
+
+        (VBType lhs, VBType rhs, VBType expected)[] grid =
+        [
+            (b, b, b), (b, e, b), (e, b, b),
+
+            (boo, boo, i), (boo, b, i), (b, boo, i), (boo, i, i), (i, boo, i), (i, i, i), (i, e, i), (e, i, i), (boo, e, i), (e, boo, i),
+            (e, e, i),
+
+            (l, b, l), (b, l, l), (l, boo, l), (l, i, l), (i, l, l), (l, l, l), (l, e, l), (e, l, l),
+
+            (ll, i, ll), (i, ll, ll), (ll, l, ll), (l, ll, ll), (ll, ll, ll), (ll, e, ll), (e, ll, ll),
+
+            (s, b, s), (b, s, s), (s, boo, s), (s, i, s), (i, s, s), (s, s, s), (s, e, s), (e, s, s),
+            (s, l, d), (l, s, d), (s, ll, d), (ll, s, d),
+
+            (d, i, d), (i, d, d), (d, d, d), (d, str, d), (str, d, d), (d, e, d), (e, d, d), (str, i, d), (i, str, d), (str, e, d),
+
+            (cur, i, cur), (i, cur, cur), (cur, cur, cur), (cur, str, cur), (str, cur, cur), (cur, e, cur), (e, cur, cur), (cur, d, cur),
+
+            // MS-VBAL 5.6.9.3 explicitly lists Currency as a Date runtime-semantics partner in both
+            // directions, alongside every other numeric/string/empty combination:
+            (dt, i, dt), (i, dt, dt), (dt, dt, dt), (dt, str, dt), (str, dt, dt), (dt, e, dt), (e, dt, dt),
+            (dt, cur, dt), (cur, dt, dt),
+
+            // Decimal only ever reaches this table via a Variant holding a CDec value, but MS-VBAL
+            // still specifies its own effective type here (not Currency's) and lists Date as a partner:
+            (dec, i, dec), (i, dec, dec), (dec, dec, dec), (dec, str, dec), (str, dec, dec), (dec, e, dec), (e, dec, dec),
+            (dec, cur, dec), (cur, dec, dec), (dec, dt, dec), (dt, dec, dec),
+
+            (n, i, n), (i, n, n), (n, d, n), (d, n, n), (n, cur, n), (cur, n, n), (n, dec, n), (dec, n, n),
+            (n, dt, n), (dt, n, n), (n, str, n), (str, n, n), (n, e, n), (e, n, n), (n, n, n),
+        ];
+
+        var failures = new List<string>();
+        foreach (var (lhs, rhs, expected) in grid)
+        {
+            var result = DetermineEffectiveType(Op(), lhs, rhs);
+            if (!result.IsApplicable || !Equals(result.Result, expected))
+            {
+                failures.Add($"({lhs.Name}, {rhs.Name}) expected {expected.Name}, got {(result.IsApplicable ? result.Result!.Name : "type mismatch")}");
+            }
+        }
+
+        Assert.AreEqual(0, failures.Count, string.Join(Environment.NewLine, failures));
+    }
+}

--- a/RDCore.Tests/Semantics/Runtime/BinaryArithmeticOperatorRuntimeTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/BinaryArithmeticOperatorRuntimeTests.cs
@@ -1,7 +1,8 @@
-﻿using RDCore.Runtime.Semantics.Operators.Arithmetic;
+using RDCore.Runtime.Semantics.Operators.Arithmetic;
 using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Values.Intrinsic;
+using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.Tests.Semantics.Runtime;
 
@@ -26,119 +27,170 @@ public sealed class BinaryArithmeticOperatorRuntimeTests : OperatorArithmeticRun
     [TestCategory("MS-VBAL 5.6.9.3.2 Binary '+' Operator")]
     public void Addition_LongResult_KeepsLongType_NoSilentNarrowing()
         => AssertResult<VBLongValue>(
-            Evaluate(Add(), VBLongType.TypeInfo, new VBLongValue(20_000), new VBLongValue(20_000)), 40_000);
+            Evaluate(Add(), new VBLongValue(20_000), new VBLongValue(20_000)), 40_000);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.2 Binary '+' Operator")]
     public void Addition_Byte_InRange()
         => AssertResult<VBByteValue>(
-            Evaluate(Add(), VBByteType.TypeInfo, new VBByteValue(100), new VBByteValue(100)), (byte)200);
+            Evaluate(Add(), new VBByteValue(100), new VBByteValue(100)), (byte)200);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.2 Binary '+' Operator")]
     public void Addition_Byte_Overflows()
         => AssertError(
-            Evaluate(Add(), VBByteType.TypeInfo, new VBByteValue(200), new VBByteValue(100)), VBRuntimeErrorId.Overflow);
+            Evaluate(Add(), new VBByteValue(200), new VBByteValue(100)), VBRuntimeErrorId.Overflow);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.2 Binary '+' Operator")]
     public void Addition_Integer_Overflows()
         => AssertError(
-            Evaluate(Add(), VBIntegerType.TypeInfo, new VBIntegerValue(30_000), new VBIntegerValue(30_000)), VBRuntimeErrorId.Overflow);
+            Evaluate(Add(), new VBIntegerValue(30_000), new VBIntegerValue(30_000)), VBRuntimeErrorId.Overflow);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.2 Binary '+' Operator")]
     public void Addition_Currency_KeepsFractionalPrecision()
         => AssertResult<VBCurrencyValue>(
-            Evaluate(Add(), VBCurrencyType.TypeInfo, new VBCurrencyValue(1000.0001m), new VBCurrencyValue(2000.0002m)), 3000.0003m);
+            Evaluate(Add(), new VBCurrencyValue(1000.0001m), new VBCurrencyValue(2000.0002m)), 3000.0003m);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.2 Binary '+' Operator")]
     public void Addition_DateEffectiveType_ProducesDate()
         => AssertResult<VBDateValue>(
-            Evaluate(Add(), VBDateType.TypeInfo, new VBDoubleValue(2), new VBDoubleValue(3)), 5d);
+            Evaluate(Add(), new VBDateValue(2), new VBDateValue(3)), 5d);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.3 Binary '-' Operator")]
     public void Subtraction_Long()
         => AssertResult<VBLongValue>(
-            Evaluate(Sub(), VBLongType.TypeInfo, new VBLongValue(5), new VBLongValue(3)), 2);
+            Evaluate(Sub(), new VBLongValue(5), new VBLongValue(3)), 2);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.3 Binary '-' Operator")]
     public void Subtraction_Byte_NegativeResult_Overflows()
         => AssertError(
-            Evaluate(Sub(), VBByteType.TypeInfo, new VBByteValue(50), new VBByteValue(100)), VBRuntimeErrorId.Overflow);
+            Evaluate(Sub(), new VBByteValue(50), new VBByteValue(100)), VBRuntimeErrorId.Overflow);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.3 Binary '-' Operator")]
+    public void Subtraction_Null_IsNull()
+        => AssertIsNull(Evaluate(Sub(), VBNullValue.Null, VBNullValue.Null));
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.4 Binary '*' Operator")]
     public void Multiplication_Long()
         => AssertResult<VBLongValue>(
-            Evaluate(Mul(), VBLongType.TypeInfo, new VBLongValue(1_000), new VBLongValue(1_000)), 1_000_000);
+            Evaluate(Mul(), new VBLongValue(1_000), new VBLongValue(1_000)), 1_000_000);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.4 Binary '*' Operator")]
     public void Multiplication_Integer_Overflows()
         => AssertError(
-            Evaluate(Mul(), VBIntegerType.TypeInfo, new VBIntegerValue(300), new VBIntegerValue(300)), VBRuntimeErrorId.Overflow);
+            Evaluate(Mul(), new VBIntegerValue(300), new VBIntegerValue(300)), VBRuntimeErrorId.Overflow);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.4 Binary '*' Operator")]
+    public void Multiplication_Null_IsNull()
+        => AssertIsNull(Evaluate(Mul(), VBNullValue.Null, VBNullValue.Null));
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.5 Binary '/' Operator")]
     public void Division_Double_RealQuotient()
         => AssertResult<VBDoubleValue>(
-            Evaluate(Div(), VBDoubleType.TypeInfo, new VBDoubleValue(7), new VBDoubleValue(2)), 3.5d);
+            Evaluate(Div(), new VBDoubleValue(7), new VBDoubleValue(2)), 3.5d);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.5 Binary '/' Operator")]
     public void Division_Single_RealQuotient()
         => AssertResult<VBSingleValue>(
-            Evaluate(Div(), VBSingleType.TypeInfo, new VBSingleValue(3), new VBSingleValue(2)), 1.5f);
+            Evaluate(Div(), new VBSingleValue(3), new VBSingleValue(2)), 1.5f);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.5 Binary '/' Operator")]
     public void Division_ByZero_IsDivisionByZero()
         => AssertError(
-            Evaluate(Div(), VBDoubleType.TypeInfo, new VBDoubleValue(5), new VBDoubleValue(0)), VBRuntimeErrorId.DivisionByZero);
+            Evaluate(Div(), new VBDoubleValue(5), new VBDoubleValue(0)), VBRuntimeErrorId.DivisionByZero);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.5 Binary '/' Operator")]
+    public void Division_Null_IsNull()
+        => AssertIsNull(Evaluate(Div(), VBNullValue.Null, VBNullValue.Null));
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.6 Binary '\\' Operator")]
     public void IntegerDivision_Long_TruncatesTowardZero()
         => AssertResult<VBLongValue>(
-            Evaluate(IntDiv(), VBLongType.TypeInfo, new VBLongValue(7), new VBLongValue(2)), 3);
+            Evaluate(IntDiv(), new VBLongValue(7), new VBLongValue(2)), 3);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.6 Binary '\\' Operator")]
+    public void IntegerDivision_NegativeDividend_TruncatesTowardZero()
+        // -7 \ 2 = -3 (nearest integer to -3.5 that is closer to zero), not -4 (floor).
+        => AssertResult<VBLongValue>(
+            Evaluate(IntDiv(), new VBLongValue(-7), new VBLongValue(2)), -3);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.6 Binary '\\' Operator")]
     public void IntegerDivision_ByZero_IsDivisionByZero()
         => AssertError(
-            Evaluate(IntDiv(), VBLongType.TypeInfo, new VBLongValue(7), new VBLongValue(0)), VBRuntimeErrorId.DivisionByZero);
+            Evaluate(IntDiv(), new VBLongValue(7), new VBLongValue(0)), VBRuntimeErrorId.DivisionByZero);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.6 Binary '\\' Operator")]
+    public void IntegerDivision_Null_IsNull()
+        => AssertIsNull(Evaluate(IntDiv(), VBNullValue.Null, VBNullValue.Null));
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.6 'Mod' Operator")]
     public void Modulo_Long()
         => AssertResult<VBLongValue>(
-            Evaluate(Mod(), VBLongType.TypeInfo, new VBLongValue(7), new VBLongValue(3)), 1);
+            Evaluate(Mod(), new VBLongValue(7), new VBLongValue(3)), 1);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.6 'Mod' Operator")]
+    public void Modulo_NegativeDividend_ResultTakesDividendSign()
+        // MS-VBAL: result = left operand minus (truncated quotient * right operand); VBA's own
+        // formula (a - b*(a\b)) does not take an absolute value, so -7 Mod 3 is -1, not 1.
+        => AssertResult<VBLongValue>(
+            Evaluate(Mod(), new VBLongValue(-7), new VBLongValue(3)), -1);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.6 'Mod' Operator")]
     public void Modulo_ByZero_IsDivisionByZero()
         => AssertError(
-            Evaluate(Mod(), VBLongType.TypeInfo, new VBLongValue(7), new VBLongValue(0)), VBRuntimeErrorId.DivisionByZero);
+            Evaluate(Mod(), new VBLongValue(7), new VBLongValue(0)), VBRuntimeErrorId.DivisionByZero);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.6 'Mod' Operator")]
+    public void Modulo_Null_IsNull()
+        => AssertIsNull(Evaluate(Mod(), VBNullValue.Null, VBNullValue.Null));
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.7 Binary '^' Operator")]
     public void Exponent_Double()
         => AssertResult<VBDoubleValue>(
-            Evaluate(Pow(), VBDoubleType.TypeInfo, new VBDoubleValue(2), new VBDoubleValue(10)), 1024d);
+            Evaluate(Pow(), new VBDoubleValue(2), new VBDoubleValue(10)), 1024d);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.7 Binary '^' Operator")]
     public void Exponent_ZeroToZero_IsOne()
         => AssertResult<VBDoubleValue>(
-            Evaluate(Pow(), VBDoubleType.TypeInfo, new VBDoubleValue(0), new VBDoubleValue(0)), 1d);
+            Evaluate(Pow(), new VBDoubleValue(0), new VBDoubleValue(0)), 1d);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.7 Binary '^' Operator")]
     public void Exponent_ZeroToNegative_IsInvalidProcedureCall()
         => AssertError(
-            Evaluate(Pow(), VBDoubleType.TypeInfo, new VBDoubleValue(0), new VBDoubleValue(-1)), VBRuntimeErrorId.InvalidProcedureCallOrArgument);
+            Evaluate(Pow(), new VBDoubleValue(0), new VBDoubleValue(-1)), VBRuntimeErrorId.InvalidProcedureCallOrArgument);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.7 Binary '^' Operator")]
+    public void Exponent_Null_IsNull()
+        => AssertIsNull(Evaluate(Pow(), VBNullValue.Null, VBNullValue.Null));
+
+    private static void AssertIsNull(RuntimeSemanticsEvaluationResult result)
+    {
+        Assert.IsNull(result.ErrorInfo);
+        Assert.IsInstanceOfType<VBNullValue>(result.Result);
+    }
 }

--- a/RDCore.Tests/Semantics/Runtime/BinaryIntegerDivisionOperatorEffectiveTypeTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/BinaryIntegerDivisionOperatorEffectiveTypeTests.cs
@@ -1,0 +1,59 @@
+using RDCore.Runtime.Semantics.Operators.Arithmetic;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Abstract;
+
+namespace RDCore.Tests.Semantics.Runtime;
+
+/// <summary>
+/// Characterization matrix for the <c>\</c> and <c>Mod</c> operator-specific effective-type table
+/// (MS-VBAL §5.6.9.3.6, runtime semantics) that overrides the general binary arithmetic table.
+/// </summary>
+[TestClass]
+[TestCategory("RD-VBAL §5.0.2.1 Operator Evaluation")]
+[TestCategory("MS-VBAL 5.6.9.3.6 \\ Operator and Mod Operator (runtime semantics)")]
+public sealed class BinaryIntegerDivisionOperatorEffectiveTypeTests : OperatorArithmeticRuntimeSemanticsTests
+{
+    // '\' and 'Mod' share the same effective-type determination; either vehicle exercises it.
+    private static BinaryIntegerDivisionOperatorRuntimeSemantics Op() => new(FakeProvider(), Formatter());
+
+    [TestMethod]
+    public void ResolvesEffectiveValueType_AcrossTheOperandGrid()
+    {
+        VBType b = VBByteType.TypeInfo, boo = VBBooleanType.TypeInfo, i = VBIntegerType.TypeInfo,
+            l = VBLongType.TypeInfo, ll = VBLongLongType.TypeInfo, s = VBSingleType.TypeInfo,
+            d = VBDoubleType.TypeInfo, cur = VBCurrencyType.TypeInfo, dec = VBDecimalType.TypeInfo,
+            dt = VBDateType.TypeInfo, str = VBStringType.TypeInfo, e = VBEmptyType.TypeInfo;
+
+        (VBType lhs, VBType rhs, VBType expected)[] grid =
+        [
+            // this pair alone used to fail: the effective-type override read its own left operand's
+            // type in place of the right operand's, so this row could never match and always fell
+            // through to the base table's (wrong, for '\'/'Mod') Byte-stays-Byte rule instead.
+            (b, e, i), (e, b, i),
+
+            (boo, s, i), (boo, d, i), (boo, str, i), (boo, cur, i), (boo, dt, i), (boo, dec, i),
+
+            // row 3 (Boolean/Integer, Single/Double/…) is asymmetric in MS-VBAL — there is no
+            // mirrored "RHS is Boolean/Integer" row, so Integer \ Single lands here (Integer), while
+            // Single \ Integer falls through to the general rule below (Long).
+            (i, s, i),
+
+            (s, i, l), (str, l, l), (dt, cur, l),
+            (l, str, l), (cur, dt, l),
+
+            (ll, i, ll), (i, ll, ll), (ll, str, ll), (str, ll, ll), (ll, e, ll), (e, ll, ll),
+        ];
+
+        var failures = new List<string>();
+        foreach (var (lhs, rhs, expected) in grid)
+        {
+            var result = DetermineEffectiveType(Op(), lhs, rhs);
+            if (!result.IsApplicable || !Equals(result.Result, expected))
+            {
+                failures.Add($"({lhs.Name}, {rhs.Name}) expected {expected.Name}, got {(result.IsApplicable ? result.Result!.Name : "type mismatch")}");
+            }
+        }
+
+        Assert.AreEqual(0, failures.Count, string.Join(Environment.NewLine, failures));
+    }
+}

--- a/RDCore.Tests/Semantics/Runtime/OperatorArithmeticRuntimeSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/OperatorArithmeticRuntimeSemanticsTests.cs
@@ -5,6 +5,7 @@ using RDCore.Runtime.Semantics.Operators;
 using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.AST.Expressions;
 using RDCore.SDK.Model.Errors;
+using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Intrinsic;
@@ -14,22 +15,37 @@ using RDCore.SDK.Runtime.Shared;
 using RDCore.SDK.Semantics;
 using RDCore.SDK.Semantics.Context;
 using RDCore.SDK.Services.VerboseMessages;
-using System.Reflection;
 
 namespace RDCore.Tests.Semantics.Runtime;
 
 /// <summary>
-/// Base for the arithmetic operator runtime-semantics characterization matrix. Mirrors the
-/// static-semantics harness: drive an operator over an (effective type, lhs, rhs) grid — with the
-/// operands already at the effective type, as the evaluation pipeline hands them to
-/// <c>EvaluateExpressionResult</c> — and assert the result's type + managed value, or the error id.
+/// Base for the arithmetic operator runtime-semantics characterization matrix: drives the operator
+/// through its public <c>Evaluate</c> entry point (effective-type determination, operand validation
+/// and let-coercion, then evaluation), the same path the interpreter uses.
 /// </summary>
 public abstract class OperatorArithmeticRuntimeSemanticsTests
 {
     protected static readonly SyntaxNodeId NodeId = new(TestUri.TestModuleUri().AbsolutePath, [42]);
 
     protected static IVerboseMessageBuilder Formatter() => Substitute.For<IVerboseMessageBuilder>();
-    protected static ILetCoercionRuntimeSemanticsProvider FakeProvider() => Substitute.For<ILetCoercionRuntimeSemanticsProvider>();
+
+    /// <summary>
+    /// A let-coercion provider stand-in for tests that don't exercise coercion itself: every operand
+    /// passes through unchanged, except a <see cref="VBDateValue"/> source, which converts to its
+    /// double serial value — the one conversion the arithmetic operators' own dispatch requires even
+    /// when the operator's effective type is nominally <see cref="VBDateType"/>.
+    /// </summary>
+    protected static ILetCoercionRuntimeSemanticsProvider FakeProvider()
+    {
+        var provider = Substitute.For<ILetCoercionRuntimeSemanticsProvider>();
+        provider.EvaluateLetCoercionSemantics(default!, default!, default)
+            .ReturnsForAnyArgs(call =>
+            {
+                var source = call.ArgAt<LetCoercionStackFrame>(2).SourceValue;
+                return LetCoercionResult.Success(source is VBDateValue date ? new VBDoubleValue(date.SerialValue) : source);
+            });
+        return provider;
+    }
 
     private static readonly VBBinaryOperatorExpressionNode ThrowawayBinary = new(
         "+", default, TestLocations.TestLocation,
@@ -42,34 +58,20 @@ public abstract class OperatorArithmeticRuntimeSemanticsTests
         "-", default, TestLocations.TestLocation,
         [new LiteralExpressionNode(default, TestLocations.TestLocationLHS, new VBIntegerValue((short)0))]);
 
-    private static readonly MethodInfo BinaryEval = typeof(BinaryArithmeticOperatorRuntimeSemantics).GetMethod(
-        "EvaluateExpressionResult",
-        BindingFlags.Instance | BindingFlags.NonPublic,
-        binder: null,
-        [typeof(ISymbolResolver), typeof(BinaryArithmeticOperatorSemanticContext), typeof(VBOperatorExpression), typeof(OperatorEvaluationFrame)],
-        modifiers: null)!;
-
-    private static readonly MethodInfo UnaryEval = typeof(UnaryArithmeticOperatorRuntimeSemantics).GetMethod(
-        "EvaluateExpressionResult",
-        BindingFlags.Instance | BindingFlags.NonPublic,
-        binder: null,
-        [typeof(ISymbolResolver), typeof(UnaryArithmeticOperatorSemanticContext), typeof(VBOperatorExpression), typeof(OperatorEvaluationFrame)],
-        modifiers: null)!;
+    protected static RuntimeSemanticsEvaluationResult Evaluate(
+        BinaryArithmeticOperatorRuntimeSemantics op, VBTypedValue lhs, VBTypedValue rhs)
+        => op.Evaluate(null!, new BinaryArithmeticOperatorSemanticContext(), ThrowawayBinary, lhs, rhs);
 
     protected static RuntimeSemanticsEvaluationResult Evaluate(
-        BinaryArithmeticOperatorRuntimeSemantics op, VBType effectiveType, VBTypedValue lhs, VBTypedValue rhs)
-    {
-        var frame = new OperatorEvaluationFrame(NodeId, [lhs, rhs], effectiveType);
-        return (RuntimeSemanticsEvaluationResult)BinaryEval.Invoke(
-            op, [null, new BinaryArithmeticOperatorSemanticContext(), ThrowawayBinary, frame])!;
-    }
+        UnaryArithmeticOperatorRuntimeSemantics op, VBTypedValue operand)
+        => op.Evaluate(null!, new UnaryArithmeticOperatorSemanticContext(), ThrowawayUnary, operand);
 
-    protected static RuntimeSemanticsEvaluationResult Evaluate(
-        UnaryArithmeticOperatorRuntimeSemantics op, VBType effectiveType, VBTypedValue operand)
+    /// <summary>Runs step 1 of the operator pipeline: resolves the effective value type from operand value types.</summary>
+    protected static DetermineOperatorEffectiveTypeResult DetermineEffectiveType(
+        BinaryArithmeticOperatorRuntimeSemantics op, VBType lhsType, VBType rhsType)
     {
-        var frame = new OperatorEvaluationFrame(NodeId, [operand], effectiveType);
-        return (RuntimeSemanticsEvaluationResult)UnaryEval.Invoke(
-            op, [null, new UnaryArithmeticOperatorSemanticContext(), ThrowawayUnary, frame])!;
+        var frame = new OperatorEvaluationFrame(NodeId, [lhsType.DefaultValue, rhsType.DefaultValue], VBUnknownType.TypeInfo);
+        return op.DetermineOperatorEffectiveType(null!, new BinaryArithmeticOperatorSemanticContext(), ThrowawayBinary, frame);
     }
 
     protected static void AssertResult<TValue>(RuntimeSemanticsEvaluationResult result, object expectedManaged)

--- a/RDCore.Tests/Semantics/Runtime/UnaryArithmeticOperatorRuntimeTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/UnaryArithmeticOperatorRuntimeTests.cs
@@ -1,6 +1,5 @@
-﻿using RDCore.Runtime.Semantics.Operators.Arithmetic;
+using RDCore.Runtime.Semantics.Operators.Arithmetic;
 using RDCore.SDK.Model.Errors;
-using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Values.Intrinsic;
 
 namespace RDCore.Tests.Semantics.Runtime;
@@ -21,47 +20,65 @@ public sealed class UnaryArithmeticOperatorRuntimeTests : OperatorArithmeticRunt
     [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
     public void Negation_Integer()
         => AssertResult<VBIntegerValue>(
-            Evaluate(Neg(), VBIntegerType.TypeInfo, new VBIntegerValue(5)), (short)-5);
+            Evaluate(Neg(), new VBIntegerValue(5)), (short)-5);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
     public void Negation_Long()
         => AssertResult<VBLongValue>(
-            Evaluate(Neg(), VBLongType.TypeInfo, new VBLongValue(5)), -5);
+            Evaluate(Neg(), new VBLongValue(5)), -5);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
     public void Negation_Double()
         => AssertResult<VBDoubleValue>(
-            Evaluate(Neg(), VBDoubleType.TypeInfo, new VBDoubleValue(2.5)), -2.5d);
+            Evaluate(Neg(), new VBDoubleValue(2.5)), -2.5d);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
     public void Negation_Currency()
         => AssertResult<VBCurrencyValue>(
-            Evaluate(Neg(), VBCurrencyType.TypeInfo, new VBCurrencyValue(1.5m)), -1.5m);
+            Evaluate(Neg(), new VBCurrencyValue(1.5m)), -1.5m);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
     public void Negation_IntegerMinValue_Overflows()
         => AssertError(
-            Evaluate(Neg(), VBIntegerType.TypeInfo, new VBIntegerValue(short.MinValue)), VBRuntimeErrorId.Overflow);
+            Evaluate(Neg(), new VBIntegerValue(short.MinValue)), VBRuntimeErrorId.Overflow);
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
     public void Negation_DateEffectiveType_ProducesDate()
         => AssertResult<VBDateValue>(
-            Evaluate(Neg(), VBDateType.TypeInfo, new VBDoubleValue(3)), -3d);
+            Evaluate(Neg(), new VBDateValue(3)), -3d);
+
+    [TestMethod]
+    [TestCategory("MS-VBAL 5.6.9.3.1 Unary '-' Operator")]
+    public void Negation_Null_IsNull()
+    {
+        var result = Evaluate(Neg(), VBNullValue.Null);
+        Assert.IsNull(result.ErrorInfo);
+        Assert.IsInstanceOfType<VBNullValue>(result.Result);
+    }
 
     [TestMethod]
     [TestCategory("RD-VBAL 5.6.9.3.1.1 Unary '+' Operator")]
     public void Plus_Long_IsIdentity()
         => AssertResult<VBLongValue>(
-            Evaluate(Plus(), VBLongType.TypeInfo, new VBLongValue(5)), 5);
+            Evaluate(Plus(), new VBLongValue(5)), 5);
 
     [TestMethod]
     [TestCategory("RD-VBAL 5.6.9.3.1.1 Unary '+' Operator")]
     public void Plus_Double_IsIdentity()
         => AssertResult<VBDoubleValue>(
-            Evaluate(Plus(), VBDoubleType.TypeInfo, new VBDoubleValue(-2.5)), -2.5d);
+            Evaluate(Plus(), new VBDoubleValue(-2.5)), -2.5d);
+
+    [TestMethod]
+    [TestCategory("RD-VBAL 5.6.9.3.1.1 Unary '+' Operator")]
+    public void Plus_Null_IsNull()
+    {
+        var result = Evaluate(Plus(), VBNullValue.Null);
+        Assert.IsNull(result.ErrorInfo);
+        Assert.IsInstanceOfType<VBNullValue>(result.Result);
+    }
 }


### PR DESCRIPTION
Writing the arithmetic operator characterization matrix against the public Evaluate() entry point (rather than reaching into the protected EvaluateExpressionResult seam) surfaced that the pipeline never threaded the determined effective type back into the evaluation frame, so every operator's dispatch fell through to InternalError once actually driven end-to-end. Fixing that then exposed a second, narrower gap: Date's effective type is nominally VBDateType, but MS-VBAL computes it in Double, so the let-coercion short-circuit needs to target Double specifically rather than skip coercion outright.

Also fixes three confirmed effective-type table bugs found while cross-checking RDCore.Runtime's arithmetic dispatch against MS-VBAL 5.6.9.3/5.6.9.3.6: the \ and Mod operators' own effective-type override read its left operand's type in place of the right operand's (so the override could never match), and the general binary table's Date and Decimal rows respectively omitted Currency as a valid partner and resolved to Currency's effective type instead of Decimal's own.