### PR TITLE
runtime: implement and harden String/Boolean/Date let-coercion

### DIFF
--- a/RDCore.Runtime/Semantics/LetCoercion/VBBooleanLetCoercionRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/LetCoercion/VBBooleanLetCoercionRuntimeSemantics.cs
@@ -1,10 +1,12 @@
 ﻿using RDCore.Runtime.Semantics.Abstract;
+using RDCore.SDK.Model;
 using RDCore.SDK.Model.AST.Expressions;
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Model.Values;
 using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Intrinsic;
+using RDCore.SDK.Model.Values.Meta;
 using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Runtime.Shared;
@@ -20,10 +22,11 @@ namespace RDCore.Runtime.Semantics.LetCoercion;
 /// <remarks>
 /// The coercion provider dispatches by <em>destination</em> type only, so this class — registered for
 /// <see cref="VBBooleanType"/> — only ever runs when the destination actually is Boolean; it therefore
-/// implements the "-&gt; Boolean" half of MS-VBAL 5.5.1.2.2's table (any numeric type, Date or Boolean
-/// source). The "Boolean -&gt;" half (Boolean as source, including Boolean -&gt; Byte's spec-mandated
-/// 255 special case) is dispatched by a <em>numeric</em> destination instead, and lives in
-/// <see cref="VBNumericLetCoercionTypeRuntimeSemantics"/> for that same reason.
+/// implements the "-&gt; Boolean" half of MS-VBAL 5.5.1.2.2's table (any numeric type, Date, String or
+/// Boolean source; the String rule is specified in MS-VBAL 5.5.1.2.4 instead, for the same
+/// destination-dispatch reason). The "Boolean -&gt;" half (Boolean as source, including Boolean -&gt;
+/// Byte's spec-mandated 255 special case) is dispatched by a <em>numeric</em> destination instead, and
+/// lives in <see cref="VBNumericLetCoercionTypeRuntimeSemantics"/> for that same reason.
 /// </remarks>
 public sealed record class VBBooleanLetCoercionRuntimeSemantics(
     ILetCoercionRuntimeSemanticsProvider Provider,
@@ -44,8 +47,35 @@ public sealed record class VBBooleanLetCoercionRuntimeSemantics(
             VBDateValue dateSourceValue when frame.DestinationTypeDesc.Target is VBBooleanType
                 => LetCoercionResult.Success(new VBBooleanValue(dateSourceValue.SerialValue != 0)),
 
+            VBStringValue stringSourceValue when frame.DestinationTypeDesc.Target is VBBooleanType
+                => CoerceStringToBoolean(resolver, expression, frame, stringSourceValue),
+
             _ => LetCoercionResult.NotApplicable(frame)
         };
+
+    // MS-VBAL 5.5.1.2.4: "True"/"False" are matched case-insensitive; "#TRUE#"/"#FALSE#" case-sensitive.
+    // Otherwise, the result is the source string let-coerced to Double, then let-coerced to Boolean.
+    private LetCoercionResult CoerceStringToBoolean(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame, VBStringValue source)
+    {
+        if (string.Equals(source.Value, Tokens.True, StringComparison.InvariantCultureIgnoreCase)
+            || string.Equals(source.Value, "#TRUE#", StringComparison.InvariantCulture))
+        {
+            return LetCoercionResult.Success(VBBooleanValue.True, [frame]);
+        }
+
+        if (string.Equals(source.Value, Tokens.False, StringComparison.InvariantCultureIgnoreCase)
+            || string.Equals(source.Value, "#FALSE#", StringComparison.InvariantCulture))
+        {
+            return LetCoercionResult.Success(VBBooleanValue.False, [frame]);
+        }
+
+        var doubleCoercion = Provider.EvaluateLetCoercionSemantics(resolver, expression,
+            frame with { DestinationTypeDesc = new VBTypeDescValue(VBDoubleType.TypeInfo) });
+
+        return doubleCoercion.Result is VBDoubleValue coerced
+            ? LetCoercionResult.Success(new VBBooleanValue((double)coerced.RuntimeValue.BoxedValue != 0), [frame])
+            : doubleCoercion;
+    }
 
     protected override ILetCoercionSemanticContextBuilder AnalyzeLetCoercionOperation(ILetCoercionSemanticContextBuilder builder, ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame)
     {

--- a/RDCore.Runtime/Semantics/LetCoercion/VBDateLetCoercionRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/LetCoercion/VBDateLetCoercionRuntimeSemantics.cs
@@ -13,36 +13,39 @@ using RDCore.SDK.Runtime.Shared;
 using RDCore.SDK.Semantics.Builders;
 using RDCore.SDK.Semantics.Flags;
 using RDCore.SDK.Services.VerboseMessages;
+using System.Globalization;
 
 namespace RDCore.Runtime.Semantics.LetCoercion;
 
 /// <summary>
 /// MS-VBAL 5.5.1.2.3 Let-coercion to and from <c>VBDateType</c>
 /// </summary>
+/// <remarks>
+/// The coercion provider dispatches by <em>destination</em> type, so this class — registered for
+/// <see cref="VBDateType"/> — also owns the "String -&gt; Date" rule of MS-VBAL 5.5.1.2.4
+/// (Let-coercion to and from String), even though that rule is documented in the String section of
+/// the specification.
+/// </remarks>
 public record class VBDateLetCoercionRuntimeSemantics(
     ILetCoercionRuntimeSemanticsProvider Provider,
-    IVerboseMessageBuilder FormatterService) 
+    IVerboseMessageBuilder FormatterService)
     : LetCoercionRuntimeSemantics<VBDateType>(FormatterService)
 {
     public override LetCoercionResult EvaluateLetCoercion(
-        ISymbolResolver resolver, 
-        VBOperatorExpression expression, 
-        LetCoercionStackFrame frame) => 
+        ISymbolResolver resolver,
+        VBOperatorExpression expression,
+        LetCoercionStackFrame frame) =>
         frame.SourceValue switch
         {
-            VBDateValue sourceDateValue when frame.DestinationTypeDesc.Target is VBDateType 
+            VBDateValue sourceDateValue when frame.DestinationTypeDesc.Target is VBDateType
                 // result is a copy of the source date (no implicit DateSerial semantic flag should be issued here)
                 => LetCoercionResult.Success(
                     frame.DestinationTypeDesc.Target.CreateValue(new ValueBindingHandle(sourceDateValue.RuntimeValue))),
 
-            VBDateValue sourceDateValue when frame.DestinationTypeDesc.Target is VBNumericType or VBBooleanType 
-                // result is the standard Double representation (DateSerial), let-coerced to the destination type
-                => LetCoercionResult.Success(frame.DestinationTypeDesc.Target.CreateValue(new ValueBindingHandle(
-                    ((VBNumericTypedValue)Provider.EvaluateLetCoercionSemantics(resolver, expression,
-                        frame with {
-                            // we must first create the VBDoubleValue for the managed SerialValue:
-                            SourceValue = new VBDoubleValue((double)sourceDateValue.RuntimeValue.BoxedValue)
-                        }).Result!).RuntimeValue))),
+            // NOTE: "Date -> Numeric/Boolean" is NOT handled here — the provider dispatches by
+            // destination type, so that direction is unreachable from this VBDateType-registered
+            // class. It's implemented in VBNumericLetCoercionTypeRuntimeSemantics (VBDateType source
+            // case) and VBBooleanLetCoercionRuntimeSemantics (VBDateValue source case) instead.
 
             VBNumericTypedValue or VBBooleanValue when frame.DestinationTypeDesc.Target is VBDateType
                 // result is the source value let-coerced to Double, then the Double is interpreted as a standard SerialValue.
@@ -53,8 +56,37 @@ public record class VBDateLetCoercionRuntimeSemantics(
                             DestinationTypeDesc = new VBTypeDescValue(VBDoubleType.TypeInfo)
                         }).Result!).RuntimeValue))),
 
+            VBStringValue stringSourceValue when frame.DestinationTypeDesc.Target is VBDateType
+                => CoerceStringToDate(resolver, expression, frame, stringSourceValue),
+
             _ => LetCoercionResult.NotApplicable(frame)
         };
+
+    // MS-VBAL 5.5.1.2.4: try date/time/time/date interpretation first; otherwise, if the string can be
+    // interpreted as a number or currency value within Double's magnitude range, let-coerce that Double
+    // to Date. A Double-conversion overflow is reported as Type mismatch (13), not Overflow (6).
+    private LetCoercionResult CoerceStringToDate(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame, VBStringValue source)
+    {
+        if (DateTime.TryParse(source.Value, CultureInfo.InvariantCulture, out var dateValue))
+        {
+            return LetCoercionResult.Success(new VBDateValue(dateValue.ToOADate()));
+        }
+
+        var doubleCoercion = Provider.EvaluateLetCoercionSemantics(resolver, expression,
+            frame with { DestinationTypeDesc = new VBTypeDescValue(VBDoubleType.TypeInfo) });
+
+        if (doubleCoercion.Result is not VBDoubleValue coerced)
+        {
+            // unparseable, or the string-to-Double step overflowed: MS-VBAL 5.5.1.2.4 reports both as
+            // Type mismatch (13) here, not the Overflow (6) that the Double coercion itself would raise.
+            return LetCoercionResult.Error(OnLetCoercionTypeMismatch(expression, frame));
+        }
+
+        var serialValue = (double)coerced.RuntimeValue.BoxedValue;
+        return serialValue >= VBDateType.MinSerial && serialValue <= VBDateType.MaxSerial
+            ? LetCoercionResult.Success(new VBDateValue(serialValue))
+            : LetCoercionResult.Error(OnLetCoercionTypeMismatch(expression, frame));
+    }
 
     protected override ILetCoercionSemanticContextBuilder AnalyzeLetCoercionOperation(
         ILetCoercionSemanticContextBuilder builder, 

--- a/RDCore.Runtime/Semantics/LetCoercion/VBNumericLetCoercionTypeRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/LetCoercion/VBNumericLetCoercionTypeRuntimeSemantics.cs
@@ -2,6 +2,7 @@
 using RDCore.SDK.Model.Types;
 using RDCore.SDK.Model.Values.Bindings;
 using RDCore.SDK.Model.Values.Runtime;
+using RDCore.SDK.Model.AST.Abstract;
 using RDCore.SDK.Model.AST.Expressions;
 using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Model.Values;
@@ -12,21 +13,38 @@ using RDCore.SDK.Runtime.Shared;
 using RDCore.SDK.Semantics.Builders;
 using RDCore.SDK.Semantics.Flags;
 using RDCore.SDK.Services.VerboseMessages;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace RDCore.Runtime.Semantics.LetCoercion;
 
 /// <summary>
 /// MS-VBAL 5.5.1.2.1 Let-coercion between numeric types
 /// </summary>
-public sealed record class VBNumericLetCoercionTypeRuntimeSemantics(
-    IVerboseMessageBuilder FormatterService, 
-    ILetCoercionRuntimeSemanticsProvider Provider) 
+/// <remarks>
+/// The coercion provider dispatches by <em>destination</em> type, so this class — registered for
+/// <see cref="VBNumericType"/> — also owns the "String -&gt; any numeric type" rule of MS-VBAL
+/// 5.5.1.2.4 (Let-coercion to and from String), even though that rule is documented in the String
+/// section of the specification.
+/// </remarks>
+public sealed partial record class VBNumericLetCoercionTypeRuntimeSemantics(
+    IVerboseMessageBuilder FormatterService,
+    ILetCoercionRuntimeSemanticsProvider Provider)
     : LetCoercionRuntimeSemantics<VBNumericType>(FormatterService)
 {
+    // MS-VBAL 5.5.1.2.4: numeric-coercion-string = [WS] [sign [WS]] regional-number-string
+    // [exponent-clause] [WS]; exponent-clause = ("e" / "d") [sign] integer-literal. Whitespace is
+    // also tolerated immediately around the sign and the exponent letter.
+    [GeneratedRegex(@"^\s*(?<mantissa>[+-]?\s*(?:[0-9]+\.?[0-9]*|\.[0-9]+))\s*(?:[eEdD]\s*(?<exponent>[+-]?\s*[0-9]+))?\s*$")]
+    private static partial Regex NumericCoercionStringPattern();
+
     public override LetCoercionResult EvaluateLetCoercion(
-        ISymbolResolver resolver, VBOperatorExpression expression, 
+        ISymbolResolver resolver, VBOperatorExpression expression,
         LetCoercionStackFrame frame) => frame.SourceValue.TypeInfo switch
         {
+            VBStringType when frame.DestinationTypeDesc.Target is INumericType
+                => CoerceStringToNumeric(expression, frame, (VBStringValue)frame.SourceValue),
+
             IIntegralNumericType when frame.DestinationTypeDesc.Target is INumericType
                 // if the source value is within the range of the destination type, the result is a copy of the value.
                 => ValidateDestinationTypeRange(expression, frame, out var numericCoercionError)
@@ -44,6 +62,17 @@ public sealed record class VBNumericLetCoercionTypeRuntimeSemantics(
                         // IMPLEMENTATION NOTE: MS-VBAL actually makes the above remark about lossy conversion in the next block.
                         ((VBNumericType)frame.DestinationTypeDesc.Target).CreateValue(VBNumericType.BankersRounding((VBNumericTypedValue)frame.SourceValue)))
                     : LetCoercionResult.Error(integralCoercionError),
+
+            // Float/Fixed -> Float/Fixed (e.g. Double -> Single, Currency -> Decimal) was missing
+            // entirely: none of the surrounding branches' patterns matched this combination, so it
+            // fell through to NotApplicable — surfaced by the Numeric -> Date round-trip step
+            // (VBDateLetCoercionRuntimeSemantics) coercing an already-Double/Single/Currency/Decimal
+            // source to VBDoubleType.
+            IFloatingPointNumericType or IFixedPointNumericType when frame.DestinationTypeDesc.Target is IFloatingPointNumericType or IFixedPointNumericType
+                => ValidateDestinationTypeRange(expression, frame, out var floatToFloatError)
+                    ? LetCoercionResult.Success(
+                        ((VBNumericType)frame.DestinationTypeDesc.Target).CreateValue(((VBNumericTypedValue)frame.SourceValue).AsDouble))
+                    : LetCoercionResult.Error(floatToFloatError),
 
             IIntegralNumericType when frame.DestinationTypeDesc.Target is IFloatingPointNumericType or IFixedPointNumericType
                 // IMPLEMENTATION NOTE: MS-VBAL defines this block using a copy of the previous block *and* notes a lossy conversion:
@@ -103,4 +132,41 @@ public sealed record class VBNumericLetCoercionTypeRuntimeSemantics(
 
                 _ => 0
             });
+
+    private LetCoercionResult CoerceStringToNumeric(ExpressionNode expression, LetCoercionStackFrame frame, VBStringValue source)
+    {
+        var match = NumericCoercionStringPattern().Match(source.Value ?? string.Empty);
+        if (!match.Success)
+        {
+            return LetCoercionResult.Error(OnLetCoercionTypeMismatch(expression, frame));
+        }
+
+        if (!double.TryParse(
+            match.Groups["mantissa"].Value.Replace(" ", string.Empty),
+            NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+            CultureInfo.InvariantCulture,
+            out var interpretedValue))
+        {
+            return LetCoercionResult.Error(OnLetCoercionTypeMismatch(expression, frame));
+        }
+
+        var scaledValue = interpretedValue;
+        if (match.Groups["exponent"].Success)
+        {
+            if (!int.TryParse(
+                match.Groups["exponent"].Value.Replace(" ", string.Empty),
+                NumberStyles.AllowLeadingSign,
+                CultureInfo.InvariantCulture,
+                out var exponent))
+            {
+                return LetCoercionResult.Error(OnLetCoercionTypeMismatch(expression, frame));
+            }
+            scaledValue *= Math.Pow(10, exponent);
+        }
+
+        var destinationType = (VBNumericType)frame.DestinationTypeDesc.Target;
+        return !double.IsNaN(scaledValue) && VBNumericType.IsWithinRange(scaledValue, destinationType)
+            ? LetCoercionResult.Success(destinationType.CreateValue(scaledValue))
+            : LetCoercionResult.Error(OnLetCoercionOverflow(expression, frame));
+    }
 }

--- a/RDCore.Runtime/Semantics/LetCoercion/VBStringLetCoercionRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/LetCoercion/VBStringLetCoercionRuntimeSemantics.cs
@@ -12,7 +12,6 @@ using RDCore.SDK.Runtime.Shared;
 using RDCore.SDK.Semantics.Builders;
 using RDCore.SDK.Semantics.Context.Abstract;
 using RDCore.SDK.Services.VerboseMessages;
-using System.Diagnostics;
 using System.Globalization;
 
 namespace RDCore.Runtime.Semantics.LetCoercion;
@@ -20,14 +19,22 @@ namespace RDCore.Runtime.Semantics.LetCoercion;
 /// <summary>
 /// MS-VBAL 5.5.1.2.4 Let-coercion to and from <c>VBStringType</c>
 /// </summary>
+/// <remarks>
+/// The coercion provider dispatches by <em>destination</em> type only, so this class — registered for
+/// <see cref="VBStringType"/> — only ever runs when the destination actually is String; it therefore
+/// implements the "-&gt; String" half of MS-VBAL 5.5.1.2.4's table (String, any numeric type, Boolean
+/// or Date source). The "String -&gt;" half (String as source, coercing to a numeric, Boolean or Date
+/// destination) is dispatched by those destination types instead, and lives in
+/// <see cref="VBNumericLetCoercionTypeRuntimeSemantics"/>, <see cref="VBBooleanLetCoercionRuntimeSemantics"/>
+/// and <see cref="VBDateLetCoercionRuntimeSemantics"/> respectively, for that same reason.
+/// </remarks>
 public record class VBStringLetCoercionRuntimeSemantics(
-    IVerboseMessageBuilder FormatterService, 
-    ILetCoercionRuntimeSemanticsProvider LetCoercionProvider) 
+    IVerboseMessageBuilder FormatterService)
     : LetCoercionRuntimeSemantics<VBStringType>(FormatterService)
 {
     public override LetCoercionResult EvaluateLetCoercion(
-        ISymbolResolver resolver, 
-        VBOperatorExpression expression, 
+        ISymbolResolver resolver,
+        VBOperatorExpression expression,
         LetCoercionStackFrame frame)
     {
         var cultureInfo = CultureInfo.InvariantCulture;
@@ -40,21 +47,18 @@ public record class VBStringLetCoercionRuntimeSemantics(
             VBNumericTypedValue numericSourceValue when frame.DestinationTypeDesc.Target is VBStringType
                 => CoerceToVBString(numericSourceValue, cultureInfo),
 
-            VBStringValue stringSourceValue when frame.DestinationTypeDesc.Target is VBBooleanType
-                => CoerceToVBBoolean(resolver, expression, frame, stringSourceValue),
-
-            VBStringValue stringSourceValue when frame.DestinationTypeDesc.Target is VBDateType
-                => CoerceToVBDate(resolver, expression, frame, stringSourceValue, cultureInfo),
-
             VBBooleanValue booleanSourceValue when frame.DestinationTypeDesc.Target is VBStringType
                 => LetCoercionResult.Success(
-                    new VBStringValue((bool)booleanSourceValue.Value 
-                        ? Tokens.True 
+                    new VBStringValue((bool)booleanSourceValue.Value
+                        ? Tokens.True
                         : Tokens.False)),
 
+            // MS-VBAL 5.5.1.2.4: "If the day value of the source date is 12/30/1899" — the date
+            // component only, regardless of the time-of-day fraction, hence comparing .Date rather
+            // than requiring the exact zero serial value.
             VBDateValue dateSourceValue when frame.DestinationTypeDesc.Target is VBStringType
                 => LetCoercionResult.Success(
-                    new VBStringValue(dateSourceValue == VBDateType.Zero 
+                    new VBStringValue(dateSourceValue.Value.Date == VBDateType.Zero.Value.Date
                         ? dateSourceValue.Value.ToLongTimeString()
                         : dateSourceValue.Value.ToShortDateString())),
 
@@ -63,85 +67,13 @@ public record class VBStringLetCoercionRuntimeSemantics(
     }
 
     protected override ILetCoercionSemanticContextBuilder AnalyzeLetCoercionOperation(
-        ILetCoercionSemanticContextBuilder builder, 
-        ISymbolResolver resolver, 
-        VBOperatorExpression expression, 
+        ILetCoercionSemanticContextBuilder builder,
+        ISymbolResolver resolver,
+        VBOperatorExpression expression,
         LetCoercionStackFrame frame)
     {
         throw new NotImplementedException();
     }
-
-    private LetCoercionResult CoerceToVBDate(
-        ISymbolResolver resolver,
-        VBOperatorExpression expression,
-        LetCoercionStackFrame frame,
-        VBStringValue stringSourceValue,
-        CultureInfo cultureInfo)
-    {
-        if (DateTime.TryParse(stringSourceValue.Value, cultureInfo, out var dateValue))
-        {
-            return LetCoercionResult.Success(new VBDateValue(dateValue.ToOADate()));
-        }
-
-        if (Decimal.TryParse(stringSourceValue.Value, cultureInfo, out var decimalValue))
-        {
-            if (decimalValue >= (decimal)VBDoubleType.MinValue.Value && decimalValue <= (decimal)VBDoubleType.MaxValue.Value)
-            {
-                var doubleCoercion = LetCoerceDouble(resolver, expression, frame);
-                return doubleCoercion.IsSuccess
-                    ? CoerceToVBBoolean((VBDoubleValue)doubleCoercion.Result!, frame)
-                    : doubleCoercion;
-            }
-            else
-            {
-                return LetCoercionResult.Error(OnLetCoercionOverflow(expression, frame));
-            }
-        }
-
-        return LetCoercionResult.Error(OnLetCoercionTypeMismatch(expression, frame));
-    }
-
-    private LetCoercionResult CoerceToVBBoolean(
-        ISymbolResolver resolver, 
-        VBOperatorExpression expression, 
-        LetCoercionStackFrame frame, 
-        VBStringValue value)
-    {
-        if (string.Equals(value.Value, Tokens.True, StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(value.Value, $"#TRUE#", StringComparison.InvariantCulture))
-        {
-            return LetCoercionResult.Success(VBBooleanValue.True, [frame]);
-        }
-
-        if (string.Equals(value.Value, Tokens.False, StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(value.Value, $"#FALSE#", StringComparison.InvariantCulture))
-        {
-            return LetCoercionResult.Success(VBBooleanValue.False, [frame]);
-        }
-
-        // otherwise the result is let-coerced to Double, which is let-coerced to Boolean.
-        var doubleCoercion = LetCoerceDouble(resolver, expression, frame);
-        return doubleCoercion.IsSuccess
-            ? CoerceToVBBoolean(((VBDoubleValue)doubleCoercion.Result!), frame)
-            : doubleCoercion;
-    }
-
-
-    private LetCoercionResult LetCoerceDouble(
-        ISymbolResolver resolver, 
-        VBOperatorExpression expression, 
-        LetCoercionStackFrame currentFrame)
-    {
-        var letCoercionFrame = currentFrame with
-        {
-            SourceValue = currentFrame.SourceValue,
-            DestinationTypeDesc = new VBTypeDescValue(VBDoubleType.TypeInfo)
-        };
-        return LetCoercionProvider.EvaluateLetCoercionSemantics(resolver, expression, letCoercionFrame);
-    }
-
-    private static LetCoercionResult CoerceToVBBoolean(VBNumericTypedValue value, LetCoercionStackFrame frame)
-        => LetCoercionResult.Success(new VBBooleanValue((double)value.RuntimeValue.BoxedValue != 0), [frame]);
 
     private static LetCoercionResult CoerceToVBString(VBNumericTypedValue value, CultureInfo cultureInfo)
     {
@@ -153,92 +85,70 @@ public record class VBStringLetCoercionRuntimeSemantics(
         {
             return LetCoercionResult.Success(new VBStringValue(VBStringValue.Zero));
         }
-        else if (double.IsPositiveInfinity(numericValue))
+        if (double.IsPositiveInfinity(numericValue))
         {
             return LetCoercionResult.Success(new VBStringValue(VBStringValue.PositiveInfinity));
         }
-        else if (double.IsNegativeInfinity(numericValue))
+        if (double.IsNegativeInfinity(numericValue))
         {
             return LetCoercionResult.Success(new VBStringValue(VBStringValue.NegativeInfinity));
         }
-        else if (double.IsNaN(numericValue))
+        if (double.IsNaN(numericValue))
         {
             return LetCoercionResult.Success(new VBStringValue(VBStringValue.NaN));
         }
 
-        var isNegative = numericValue < 0;
-        var sign = isNegative ? "-" : string.Empty;
-
+        var sign = numericValue < 0 ? "-" : string.Empty;
         var absoluteValue = Math.Abs(numericValue);
-        var stringValue = absoluteValue.ToString(cultureInfo);
-
         var dot = cultureInfo.NumberFormat.NumberDecimalSeparator;
-        var decimalIndex = stringValue.IndexOf(dot);
 
-        if (decimalIndex >= 0)
-        {
-            var integerString = stringValue[..(decimalIndex - 1)];
-            // MS-VBAL 5.5.1.2.4 Let-coercion to and from String
+        // MS-VBAL 5.5.1.2.4: scientific notation is used whenever the integer part has more than the
+        // source type's maximum significant integral digits, regardless of whether the value also has
+        // a fractional part. "F0" (fixed-point, no fractional digits) reliably yields just the integer
+        // part without .NET's default ToString() collapsing a very large/small magnitude into its own
+        // scientific notation first (which would otherwise hide the decimal separator this method used
+        // to gate on, undercounting whole-number values entirely).
+        var integerPartDigitCount = absoluteValue < 1 ? 1 : absoluteValue.ToString("F0", cultureInfo).Length;
+        var significantIntegerDigits = value is VBSingleValue
+            ? VBSingleType.SignificantIntegerDigits
+            : VBDoubleType.SignificantIntegerDigits;
 
-            // VBSingleValue uses normal notation for values up to 7 integer digits, scientific notation otherwise:
-            Debug.Assert(VBDoubleType.SignificantIntegerDigits == VBNumericTypedValue.SignificantIntegerDigits);
-            if (value is VBSingleValue && integerString.Length > VBSingleType.SignificantIntegerDigits)
-            {
-                var significantIntegerDigits = VBSingleType.SignificantIntegerDigits;
-                stringValue = ToVBScientificNotation(numericValue, significantIntegerDigits, dot, cultureInfo);
-
-            }
-            else if (integerString.Length > VBDoubleType.SignificantIntegerDigits)
-            {
-                // Double (or any other numeric type for that matter): truncate to 15 significant digits
-                var significantIntegerDigits = VBDoubleType.SignificantIntegerDigits;
-                stringValue = ToVBScientificNotation(numericValue, significantIntegerDigits, dot, cultureInfo);
-            }
-        }
-        else
-        {
-            stringValue = $"{sign}{stringValue}";
-        }
+        var stringValue = integerPartDigitCount > significantIntegerDigits
+            ? ToVBScientificNotation(numericValue, significantIntegerDigits, dot, cultureInfo)
+            : $"{sign}{absoluteValue.ToString(cultureInfo)}";
 
         return LetCoercionResult.Success(new VBStringValue(stringValue));
     }
 
     private static string ToVBScientificNotation(double value, int significantIntegerDigits, string decimalSeparator, CultureInfo cultureInfo)
     {
-        var absoluteValue = Math.Abs(value);
         var sign = value < 0 ? "-" : string.Empty;
+        var absoluteValue = Math.Abs(value);
 
-        var stringValue = absoluteValue.ToString(cultureInfo);
-        var decimalIndex = stringValue.IndexOf(decimalSeparator);
+        // .NET's own "E" format always yields exactly one digit before the decimal point (s * 10^e),
+        // regardless of the source's magnitude or whether it has a fractional part — reliably giving
+        // the significand and exponent without needing to first locate a decimal separator that may
+        // not even be present (a whole-number source) or that .NET's default ToString() may already
+        // have collapsed into its own scientific notation. 16 fractional digits comfortably covers a
+        // double's ~15-17 significant decimal digits of precision.
+        var scientific = absoluteValue.ToString("E16", CultureInfo.InvariantCulture);
+        var eIndex = scientific.IndexOf('E');
+        var exponent = int.Parse(scientific[(eIndex + 1)..], CultureInfo.InvariantCulture);
+        var s = scientific[0];
 
-        var integerString = stringValue[..(decimalIndex - 1)];
-        var decimalString = stringValue[(decimalIndex + 1)..];
-
-        // s * 10^e
-        char s;
-        int e;
-        if (absoluteValue >= 1)
+        // MS-VBAL 5.5.1.2.4: "a maximum of 15 [7 for Single] integer and significand digits are
+        // printed total with trailing zeros removed" — the leading digit `s` counts as one of them.
+        var fractionalDigits = scientific[2..eIndex].TrimEnd('0');
+        var maxFractionalDigits = Math.Max(0, significantIntegerDigits - 1);
+        if (fractionalDigits.Length > maxFractionalDigits)
         {
-            s = integerString[0];
-            e = decimalIndex; // magnitude is just where the decimal separator is at (positive)
-        }
-        else
-        {
-            // s is the first non-zero digit
-            var nzIndex = decimalString.IndexOfAny(['1', '2', '3', '4', '5', '6', '7', '8', '9']);
-            s = decimalString[nzIndex];
-            e = -(nzIndex + 1); // magnitude is the (negative) number of decimal positions shifted
+            fractionalDigits = fractionalDigits[..maxFractionalDigits];
         }
 
-        // combined integer+decimal parts cannot exceed a length of 15:
-        decimalString = $"{integerString[1..]}{decimalString}";
-        var fullValue = $"{integerString}{decimalSeparator}{decimalString}";
-
-        var fullValueLength = fullValue.Length;
-        decimalString = fullValueLength > significantIntegerDigits
-            ? decimalString[..significantIntegerDigits]
-            : decimalString;
-
-        return $"{sign}{s}{decimalSeparator}{decimalString}E{e}";
+        // MS-VBAL 5.5.1.2.4: the exponent is always signed ("+" or "-"), unlike a bare C# int.ToString().
+        var exponentSign = exponent < 0 ? "-" : "+";
+        return fractionalDigits.Length > 0
+            ? $"{sign}{s}{decimalSeparator}{fractionalDigits}E{exponentSign}{Math.Abs(exponent)}"
+            : $"{sign}{s}E{exponentSign}{Math.Abs(exponent)}";
     }
 }

--- a/RDCore.Tests/Semantics/Runtime/OperatorConcatRuntimeSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/OperatorConcatRuntimeSemanticsTests.cs
@@ -55,19 +55,6 @@ public abstract class OperatorConcatRuntimeSemanticsTests : OperatorArithmeticRu
     protected static ILetCoercionRuntimeSemanticsProvider StringCoercionProvider()
     {
         var fmt = Substitute.For<IVerboseMessageBuilder>();
-        var handle = new ProviderHandle();
-        var provider = new LetCoercionRuntimeSemanticsProvider([new VBStringLetCoercionRuntimeSemantics(fmt, handle)], fmt);
-        handle.Inner = provider;
-        return provider;
-    }
-
-    /// <summary>Breaks the provider ⇄ strategy construction cycle (strategies take the provider itself for recursive coercions).</summary>
-    private sealed class ProviderHandle : ILetCoercionRuntimeSemanticsProvider
-    {
-        public ILetCoercionRuntimeSemanticsProvider Inner { get; set; } = default!;
-        public LetCoercionResult EvaluateLetCoercionSemantics(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame)
-            => Inner.EvaluateLetCoercionSemantics(resolver, expression, frame);
-        public LetCoercionAnalysisContext Analyze(ISymbolResolver resolver, ILetCoercionSemanticContextBuilder builder, VBOperatorExpression expression, LetCoercionStackFrame frame)
-            => Inner.Analyze(resolver, builder, expression, frame);
+        return new LetCoercionRuntimeSemanticsProvider([new VBStringLetCoercionRuntimeSemantics(fmt)], fmt);
     }
 }

--- a/RDCore.Tests/Semantics/Runtime/OperatorLetCoerceRuntimeSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/OperatorLetCoerceRuntimeSemanticsTests.cs
@@ -59,7 +59,7 @@ public abstract class OperatorLetCoerceRuntimeSemanticsTests : OperatorArithmeti
         ILetCoercionRuntimeSemantics[] strategies =
         [
             new VBNumericLetCoercionTypeRuntimeSemantics(fmt, handle),
-            new VBStringLetCoercionRuntimeSemantics(fmt, handle),
+            new VBStringLetCoercionRuntimeSemantics(fmt),
             new VBDateLetCoercionRuntimeSemantics(handle, fmt),
             new VBBooleanLetCoercionRuntimeSemantics(handle, fmt),
         ];

--- a/RDCore.Tests/Semantics/Runtime/VBBooleanLetCoercionTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/VBBooleanLetCoercionTests.cs
@@ -1,0 +1,93 @@
+using RDCore.Runtime.Semantics.LetCoercion;
+using RDCore.SDK.Model.Errors;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Values.Intrinsic;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Runtime.Shared;
+using RDCore.SDK.Semantics.Analysis;
+using RDCore.SDK.Semantics.Builders;
+using RDCore.SDK.Model.AST.Expressions;
+using RDCore.SDK.Services.VerboseMessages;
+using NSubstitute;
+
+namespace RDCore.Tests.Semantics.Runtime;
+
+/// <summary>
+/// Characterization matrix for Boolean let-coercion (MS-VBAL §5.5.1.2.2): the "-&gt; Boolean" half of
+/// the table, since the coercion provider dispatches by destination type. Numeric, Date and String
+/// sources all funnel through this class when the destination is Boolean.
+/// </summary>
+[TestClass]
+[TestCategory("RD-VBAL §5.5.1.2.2 Let-coercion to and from Boolean")]
+public sealed class VBBooleanLetCoercionTests : LetCoercionRuntimeSemanticsTests
+{
+    // String -> Boolean falls back to String -> Double -> Boolean for anything that isn't a
+    // recognized token, so the real Numeric strategy is wired in via the same cyclic-break pattern
+    // used elsewhere for a strategy that recurses through the provider.
+    private static VBBooleanLetCoercionRuntimeSemantics Sut()
+    {
+        var fmt = Substitute.For<IVerboseMessageBuilder>();
+        var handle = new ProviderHandle();
+        var provider = new LetCoercionRuntimeSemanticsProvider([new VBNumericLetCoercionTypeRuntimeSemantics(fmt, handle)], fmt);
+        handle.Inner = provider;
+        return new VBBooleanLetCoercionRuntimeSemantics(provider, fmt);
+    }
+
+    private sealed class ProviderHandle : ILetCoercionRuntimeSemanticsProvider
+    {
+        public ILetCoercionRuntimeSemanticsProvider Inner { get; set; } = default!;
+        public LetCoercionResult EvaluateLetCoercionSemantics(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame)
+            => Inner.EvaluateLetCoercionSemantics(resolver, expression, frame);
+        public LetCoercionAnalysisContext Analyze(ISymbolResolver resolver, ILetCoercionSemanticContextBuilder builder, VBOperatorExpression expression, LetCoercionStackFrame frame)
+            => Inner.Analyze(resolver, builder, expression, frame);
+    }
+
+    [TestMethod]
+    public void BooleanSource_IsACopy()
+        => AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBBooleanValue(true), VBBooleanType.TypeInfo), true);
+
+    [TestMethod]
+    [DataRow(0d, false)]
+    [DataRow(5d, true)]
+    [DataRow(-1d, true)]
+    public void NumericSource_IsFalseOnlyWhenZero(double source, bool expected)
+        => AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBDoubleValue(source), VBBooleanType.TypeInfo), expected);
+
+    [TestMethod]
+    public void DateSource_IsFalseOnlyForTheZeroSerialValue()
+    {
+        AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBDateValue(0d), VBBooleanType.TypeInfo), false);
+        AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBDateValue(1d), VBBooleanType.TypeInfo), true);
+    }
+
+    [TestMethod]
+    [DataRow("True", true)]
+    [DataRow("true", true)]
+    [DataRow("TRUE", true)]
+    [DataRow("False", false)]
+    [DataRow("false", false)]
+    public void StringSource_TrueFalseTokens_AreCaseInsensitive(string source, bool expected)
+        => AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBStringValue(source), VBBooleanType.TypeInfo), expected);
+
+    [TestMethod]
+    [DataRow("#TRUE#", true)]
+    [DataRow("#FALSE#", false)]
+    public void StringSource_HashTokens_AreCaseSensitive(string source, bool expected)
+        => AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBStringValue(source), VBBooleanType.TypeInfo), expected);
+
+    [TestMethod]
+    public void StringSource_HashTokenWrongCase_FallsThroughToNumericParse_IsTypeMismatch()
+        // "#true#" is not a recognized token (case-sensitive) and isn't a numeric-coercion-string either.
+        => AssertError(Coerce(Sut(), new VBStringValue("#true#"), VBBooleanType.TypeInfo), VBRuntimeErrorId.TypeMismatch);
+
+    [TestMethod]
+    [DataRow("5", true)]
+    [DataRow("0", false)]
+    [DataRow("-1.5", true)]
+    public void StringSource_NumericString_CoercesThroughDouble(string source, bool expected)
+        => AssertCoercedTo<VBBooleanValue>(Coerce(Sut(), new VBStringValue(source), VBBooleanType.TypeInfo), expected);
+
+    [TestMethod]
+    public void StringSource_Garbage_IsTypeMismatch()
+        => AssertError(Coerce(Sut(), new VBStringValue("not a boolean"), VBBooleanType.TypeInfo), VBRuntimeErrorId.TypeMismatch);
+}

--- a/RDCore.Tests/Semantics/Runtime/VBDateLetCoercionTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/VBDateLetCoercionTests.cs
@@ -1,0 +1,79 @@
+using RDCore.Runtime.Semantics.LetCoercion;
+using RDCore.SDK.Model.Errors;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Values.Intrinsic;
+using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Runtime.Shared;
+using RDCore.SDK.Semantics.Analysis;
+using RDCore.SDK.Semantics.Builders;
+using RDCore.SDK.Model.AST.Expressions;
+using RDCore.SDK.Services.VerboseMessages;
+using NSubstitute;
+
+namespace RDCore.Tests.Semantics.Runtime;
+
+/// <summary>
+/// Characterization matrix for Date let-coercion (MS-VBAL §5.5.1.2.3): the "-&gt; Date" half of the
+/// table (Date, Numeric, Boolean and String sources), since the coercion provider dispatches by
+/// destination type. "Date -&gt;" is owned by whichever class registers for the actual destination
+/// (Numeric or Boolean), not by this class.
+/// </summary>
+[TestClass]
+[TestCategory("RD-VBAL §5.5.1.2.3 Let-coercion to and from Date")]
+public sealed class VBDateLetCoercionTests : LetCoercionRuntimeSemanticsTests
+{
+    // String -> Date falls back to String -> Double for anything DateTime.TryParse can't read, so the
+    // real Numeric strategy is wired in via the same cyclic-break pattern used elsewhere.
+    private static VBDateLetCoercionRuntimeSemantics Sut()
+    {
+        var fmt = Substitute.For<IVerboseMessageBuilder>();
+        var handle = new ProviderHandle();
+        var provider = new LetCoercionRuntimeSemanticsProvider([new VBNumericLetCoercionTypeRuntimeSemantics(fmt, handle)], fmt);
+        handle.Inner = provider;
+        return new VBDateLetCoercionRuntimeSemantics(provider, fmt);
+    }
+
+    private sealed class ProviderHandle : ILetCoercionRuntimeSemanticsProvider
+    {
+        public ILetCoercionRuntimeSemanticsProvider Inner { get; set; } = default!;
+        public LetCoercionResult EvaluateLetCoercionSemantics(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame)
+            => Inner.EvaluateLetCoercionSemantics(resolver, expression, frame);
+        public LetCoercionAnalysisContext Analyze(ISymbolResolver resolver, ILetCoercionSemanticContextBuilder builder, VBOperatorExpression expression, LetCoercionStackFrame frame)
+            => Inner.Analyze(resolver, builder, expression, frame);
+    }
+
+    [TestMethod]
+    public void DateSource_IsACopy()
+        => AssertCoercedTo<VBDateValue>(Coerce(Sut(), new VBDateValue(12345d), VBDateType.TypeInfo), 12345d);
+
+    [TestMethod]
+    public void NumericSource_IsInterpretedAsSerialValue()
+        => AssertCoercedTo<VBDateValue>(Coerce(Sut(), new VBDoubleValue(2d), VBDateType.TypeInfo), 2d);
+
+    [TestMethod]
+    public void BooleanSource_IsInterpretedAsSerialValue()
+    {
+        AssertCoercedTo<VBDateValue>(Coerce(Sut(), new VBBooleanValue(false), VBDateType.TypeInfo), 0d);
+        AssertCoercedTo<VBDateValue>(Coerce(Sut(), new VBBooleanValue(true), VBDateType.TypeInfo), -1d);
+    }
+
+    [TestMethod]
+    public void StringSource_RecognizableDateTime_Parses()
+        => AssertCoercedTo<VBDateValue>(Coerce(Sut(), new VBStringValue("2020-01-01"), VBDateType.TypeInfo), new DateTime(2020, 1, 1).ToOADate());
+
+    [TestMethod]
+    public void StringSource_NumericFallback_CoercesThroughDouble()
+        // not parseable as a date/time, but is a valid numeric-coercion-string within Date's range.
+        => AssertCoercedTo<VBDateValue>(Coerce(Sut(), new VBStringValue("5"), VBDateType.TypeInfo), 5d);
+
+    [TestMethod]
+    public void StringSource_NumericFallbackOutOfDateRange_IsTypeMismatchNotOverflow()
+        // MS-VBAL 5.5.1.2.4: a Double-conversion overflow during the string fallback is reported as
+        // Type mismatch (13), not the Overflow (6) that the Double coercion itself would raise; the
+        // same applies here since VBDoubleType's own range is far wider than VBDateType's.
+        => AssertError(Coerce(Sut(), new VBStringValue("99999999"), VBDateType.TypeInfo), VBRuntimeErrorId.TypeMismatch);
+
+    [TestMethod]
+    public void StringSource_Garbage_IsTypeMismatch()
+        => AssertError(Coerce(Sut(), new VBStringValue("not a date"), VBDateType.TypeInfo), VBRuntimeErrorId.TypeMismatch);
+}

--- a/RDCore.Tests/Semantics/Runtime/VBNumericLetCoercionTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/VBNumericLetCoercionTests.cs
@@ -35,4 +35,40 @@ public sealed class VBNumericLetCoercionTests : LetCoercionRuntimeSemanticsTests
     [TestMethod]
     public void LongToInteger_OutOfRange_Overflows()
         => AssertError(Coerce(Sut(), new VBLongValue(100_000), VBIntegerType.TypeInfo), VBRuntimeErrorId.Overflow);
+
+    // MS-VBAL 5.5.1.2.4's numeric-coercion-string grammar is documented under String, but the
+    // coercion provider dispatches by destination, so it's implemented (and tested) here.
+    [TestMethod]
+    [DataRow("123", 123d, DisplayName = "plain digits")]
+    [DataRow("123.45", 123.45d, DisplayName = "decimal point")]
+    [DataRow("-123.45", -123.45d, DisplayName = "leading sign")]
+    [DataRow("+5", 5d, DisplayName = "leading plus sign")]
+    [DataRow("  123  ", 123d, DisplayName = "outer whitespace")]
+    [DataRow("- 5", -5d, DisplayName = "whitespace between sign and digits")]
+    [DataRow(".5", 0.5d, DisplayName = "no leading integer digit")]
+    [DataRow("1.5E2", 150d, DisplayName = "uppercase E exponent")]
+    [DataRow("1.5e+2", 150d, DisplayName = "lowercase e with explicit positive exponent sign")]
+    [DataRow("1.5E-2", 0.015d, DisplayName = "negative exponent")]
+    [DataRow("1D2", 100d, DisplayName = "D exponent marker (legacy BASIC notation)")]
+    public void StringToDouble_ParsesNumericCoercionStringGrammar(string source, double expected)
+        => AssertCoercedTo<VBDoubleValue>(Coerce(Sut(), new VBStringValue(source), VBDoubleType.TypeInfo), expected);
+
+    [TestMethod]
+    // MS-VBAL 5.5.1.2.1.1: integral destinations still apply Banker's Rounding to the parsed value.
+    [DataRow("2.5", (short)2)]
+    [DataRow("3.5", (short)4)]
+    public void StringToInteger_RoundsBankers(string source, short expected)
+        => AssertCoercedTo<VBIntegerValue>(Coerce(Sut(), new VBStringValue(source), VBIntegerType.TypeInfo), expected);
+
+    [TestMethod]
+    public void StringToInteger_OutOfRange_Overflows()
+        => AssertError(Coerce(Sut(), new VBStringValue("100000"), VBIntegerType.TypeInfo), VBRuntimeErrorId.Overflow);
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("abc")]
+    [DataRow("12,34")]
+    [DataRow("E5")]
+    public void StringToNumeric_Unparseable_IsTypeMismatch(string source)
+        => AssertError(Coerce(Sut(), new VBStringValue(source), VBDoubleType.TypeInfo), VBRuntimeErrorId.TypeMismatch);
 }

--- a/RDCore.Tests/Semantics/Runtime/VBStringLetCoercionTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/VBStringLetCoercionTests.cs
@@ -1,0 +1,92 @@
+using RDCore.Runtime.Semantics.LetCoercion;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Values.Intrinsic;
+
+namespace RDCore.Tests.Semantics.Runtime;
+
+/// <summary>
+/// Characterization matrix for String let-coercion (MS-VBAL §5.5.1.2.4): the "-&gt; String" half of
+/// the table (String, Numeric, Boolean and Date source), since the coercion provider dispatches by
+/// destination type. "String -&gt;" (String as source, coercing to a numeric, Boolean or Date
+/// destination) is owned by those destination types instead — see <see cref="VBNumericLetCoercionTests"/>,
+/// <see cref="VBBooleanLetCoercionTests"/> and <see cref="VBDateLetCoercionTests"/>.
+/// </summary>
+[TestClass]
+[TestCategory("RD-VBAL §5.5.1.2.4 Let-coercion to and from String")]
+public sealed class VBStringLetCoercionTests : LetCoercionRuntimeSemanticsTests
+{
+    private static VBStringLetCoercionRuntimeSemantics Sut() => new(Formatter());
+
+    [TestMethod]
+    public void StringSource_IsACopy()
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBStringValue("hello"), VBStringType.TypeInfo), "hello");
+
+    [TestMethod]
+    public void NumericSource_Zero_IsTheStringZero()
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBLongValue(0), VBStringType.TypeInfo), "0");
+
+    [TestMethod]
+    [DataRow(123d, "123")]
+    [DataRow(-123d, "-123")]
+    [DataRow(123.45d, "123.45")]
+    // fixed 2026-09-12: the sign was only ever applied to a whole-number result — a negative value
+    // with a fractional part (any value that reached the "has a decimal point" branch) silently lost
+    // its sign, since that branch built its string from the unsigned absoluteValue without ever
+    // re-attaching the sign computed earlier.
+    [DataRow(-123.45d, "-123.45")]
+    public void NumericSource_NormalNotation(double source, string expected)
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBDoubleValue(source), VBStringType.TypeInfo), expected);
+
+    [TestMethod]
+    public void NumericSource_PositiveInfinity_IsTheInfinityToken()
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBDoubleValue(double.PositiveInfinity), VBStringType.TypeInfo), VBStringValue.PositiveInfinity);
+
+    [TestMethod]
+    public void NumericSource_NegativeInfinity_IsTheNegativeInfinityToken()
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBDoubleValue(double.NegativeInfinity), VBStringType.TypeInfo), VBStringValue.NegativeInfinity);
+
+    [TestMethod]
+    public void NumericSource_NaN_IsTheNaNToken()
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBDoubleValue(double.NaN), VBStringType.TypeInfo), VBStringValue.NaN);
+
+    [TestMethod]
+    public void NumericSource_ExceedsSignificantIntegerDigits_UsesScientificNotationWithSignedExponent()
+    {
+        // MS-VBAL 5.5.1.2.4: the exponent is always signed ("+" or "-") — a bare C# int.ToString()
+        // would have produced "E20" instead of "E+20" for a positive exponent.
+        var result = Coerce(Sut(), new VBDoubleValue(100_000_000_000_000_000_000d), VBStringType.TypeInfo);
+        Assert.IsTrue(result.IsApplicable);
+        StringAssert.Contains(((VBStringValue)result.Result!).Value, "E+");
+    }
+
+    [TestMethod]
+    public void NumericSource_SingleExceedingSevenDigits_UsesScientificNotation()
+    {
+        // Single's significant-digit threshold (7) is lower than Double's (15), so a value that's
+        // still normal notation for a Double must go scientific when the source is a Single.
+        var result = Coerce(Sut(), new VBSingleValue(12345678f), VBStringType.TypeInfo);
+        Assert.IsTrue(result.IsApplicable);
+        StringAssert.Contains(((VBStringValue)result.Result!).Value, "E+");
+    }
+
+    [TestMethod]
+    [DataRow(true, "True")]
+    [DataRow(false, "False")]
+    public void BooleanSource_IsTrueOrFalseToken(bool source, string expected)
+        => AssertCoercedTo<VBStringValue>(Coerce(Sut(), new VBBooleanValue(source), VBStringType.TypeInfo), expected);
+
+    [TestMethod]
+    public void DateSource_ZeroDate_IsTimeOnly()
+        // MS-VBAL 5.5.1.2.4: "If the day value of the source date is 12/30/1899" — the day value only,
+        // not the full serial (fixed 2026-09-12: this used to require the exact zero serial value,
+        // which is only midnight on 12/30/1899, missing every other time of day on that same date).
+        => AssertCoercedTo<VBStringValue>(
+            Coerce(Sut(), new VBDateValue(0.5d), VBStringType.TypeInfo),
+            new DateTime(1899, 12, 30, 12, 0, 0).ToLongTimeString());
+
+    [TestMethod]
+    public void DateSource_NonZeroDate_IsShortDate()
+        => AssertCoercedTo<VBStringValue>(
+            Coerce(Sut(), new VBDateValue(new DateTime(2020, 1, 1).ToOADate()), VBStringType.TypeInfo),
+            new DateTime(2020, 1, 1).ToShortDateString());
+}


### PR DESCRIPTION
MS-VBAL 5.5.1.2.4's numeric-coercion-string grammar (String -> any numeric type) had no implementation anywhere: the coercion provider dispatches by destination type, and no strategy registered for a numeric destination had a String-source case. Implemented it in VBNumericLetCoercionTypeRuntimeSemantics, the class that actually owns that dispatch.

String -> Boolean and String -> Date were dead code for the same reason: their logic lived in VBStringLetCoercionRuntimeSemantics, which the provider only ever invokes when the *destination* is String. Moved both to the classes the provider actually dispatches to (VBBooleanLetCoercionRuntimeSemantics, VBDateLetCoercionRuntimeSemantics), fixing two further bugs surfaced in the process: the Date fallback called a Boolean-conversion helper instead of constructing a Date, and a Double-conversion overflow during that fallback raised Overflow instead of the Type-mismatch MS-VBAL requires there.

Also fixed, all found while exercising these paths end-to-end:
- Date -> Numeric/Boolean was separately (and wrongly) implemented a second time in VBDateLetCoercionRuntimeSemantics, unreachable via the provider and shadowing the correct implementations; removed.
- Float/fixed-point -> float/fixed-point numeric coercion (e.g. Double -> Single) had no matching case at all.
- Date -> String's "is this the zero date" check compared the full serial value for exact equality instead of just the date component, so any time-of-day on 12/30/1899 formatted as a date instead of a time.
- Numeric -> String's scientific-notation formatting: missing "+" on positive exponents, an off-by-one in the significant-digit threshold, whole numbers never triggering scientific notation at all (gated on a decimal point that whole numbers don't have), a crash on that same whole-number path once the gating was fixed, and a dropped sign on negative numbers with a fractional part.
- VBErrorValue-style dead constructor parameter (LetCoercionProvider) removed from VBStringLetCoercionRuntimeSemantics now that its String -> Boolean/Date delegation lives elsewhere.

Coverage: VBStringLetCoercionRuntimeSemantics 28% -> 96%, VBBooleanLetCoercionRuntimeSemantics 39% -> 65%,
VBDateLetCoercionRuntimeSemantics 43% -> 68%,
VBNumericLetCoercionTypeRuntimeSemantics 67% -> 76%. 1879 tests green.