### PR TITLE
fix stack overflow in VBType/VBTypedValue equality and tostring

### DIFF
--- a/RDCore.SDK/Model/Types/Abstract/VBType.cs
+++ b/RDCore.SDK/Model/Types/Abstract/VBType.cs
@@ -1,5 +1,6 @@
 ﻿using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Bindings;
+using System.Text;
 using System.Text.Json.Serialization;
 
 namespace RDCore.SDK.Model.Types.Abstract;
@@ -62,4 +63,21 @@ public abstract record class VBType
     /// </remarks>
     public virtual VBTypedValue CreateValue(IBindingHandle handle)
         => throw new NotSupportedException($"A value of type '{Name}' cannot be constructed from a binding handle.");
+
+    /// <summary>
+    /// Prints this <c>VBType</c>'s members for <see cref="object.ToString"/>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately omits <see cref="DefaultValue"/>: every <c>VBTypedValue</c> carries its own
+    /// <c>TypeInfo</c> pointing back at the <c>VBType</c> that produced it, so printing
+    /// <c>DefaultValue</c> here and letting the compiler-generated <c>ToString</c> take its usual
+    /// course would recurse between the two <c>PrintMembers</c> implementations forever.
+    /// </remarks>
+    protected virtual bool PrintMembers(StringBuilder builder)
+    {
+        builder.Append("ManagedType = ").Append(ManagedType);
+        builder.Append(", Name = ").Append(Name);
+        builder.Append(", IsHidden = ").Append(IsHidden);
+        return true;
+    }
 }

--- a/RDCore.SDK/Model/Types/Complex/VBUserDefinedType.cs
+++ b/RDCore.SDK/Model/Types/Complex/VBUserDefinedType.cs
@@ -25,8 +25,18 @@ public record class VBUserDefinedType(Symbol Symbol, ImmutableArray<VBTypeMember
 
     public IVBMemberOwnerType WithMembers(IEnumerable<VBTypeMemberSymbol> members) => this with { Members = [.. members] };
 
-    public virtual bool Equals(VBUserDefinedType? other) => other is VBUserDefinedType udt && udt.Symbol.Uri == Symbol.Uri;
-    public override int GetHashCode() => Symbol.Uri.GetHashCode();
+    /// <remarks>
+    /// Compares by the declaring symbol's <c>Uri</c> instead of the compiler-generated deep
+    /// structural comparison: <see cref="Members"/> can reference field symbols whose own
+    /// <c>ResolvedType</c> loops back to this very UDT, which the default record equality has no way
+    /// to guard against. Compares <c>Uri.AbsoluteUri</c> as an ordinal string rather than using
+    /// <see cref="Uri"/>'s own <c>Equals</c>/<c>GetHashCode</c>: those deliberately ignore
+    /// <c>Uri.Fragment</c>, and a symbol's discriminating name/location is encoded entirely in the
+    /// fragment here — two distinct UDTs sharing a workspace root would otherwise compare equal.
+    /// </remarks>
+    public virtual bool Equals(VBUserDefinedType? other)
+        => other is VBUserDefinedType udt && string.Equals(udt.Symbol.Uri.AbsoluteUri, Symbol.Uri.AbsoluteUri, StringComparison.Ordinal);
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Symbol.Uri.AbsoluteUri);
 }
 
 /// <summary>

--- a/RDCore.SDK/Model/Values/Abstract/VBTypedValue.cs
+++ b/RDCore.SDK/Model/Values/Abstract/VBTypedValue.cs
@@ -4,6 +4,7 @@ using RDCore.SDK.Model.Values;
 using RDCore.SDK.Model.Values.Bindings;
 using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Model.Values.Meta;
+using System.Text;
 using System.Text.Json.Serialization;
 namespace RDCore.SDK.Model.Values.Abstract;
 
@@ -100,4 +101,20 @@ public abstract record class VBTypedValue(VBType TypeInfo)
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(EqualityContract, BoundManagedValue);
+
+    /// <summary>
+    /// Prints this <c>VBTypedValue</c>'s members for <see cref="object.ToString"/>.
+    /// </summary>
+    /// <remarks>
+    /// Prints <see cref="TypeInfo"/> by <see cref="VBType.Name"/> rather than the <c>VBType</c>
+    /// instance itself: that type's own <see cref="VBType.DefaultValue"/> is this kind of value, so
+    /// letting the compiler-generated <c>ToString</c> print the full <c>TypeInfo</c> object would
+    /// recurse between the two <c>PrintMembers</c> implementations forever.
+    /// </remarks>
+    protected virtual bool PrintMembers(StringBuilder builder)
+    {
+        builder.Append("TypeInfo = ").Append(TypeInfo.Name);
+        builder.Append(", Handle = ").Append(Handle);
+        return true;
+    }
 }

--- a/RDCore.Tests/Model/Types/VBUserDefinedTypeTests.cs
+++ b/RDCore.Tests/Model/Types/VBUserDefinedTypeTests.cs
@@ -1,0 +1,80 @@
+using RDCore.SDK.Model;
+using RDCore.SDK.Model.Source;
+using RDCore.SDK.Model.Symbols.Abstract;
+using RDCore.SDK.Model.Symbols.VBProject;
+using RDCore.SDK.Model.Types;
+using RDCore.SDK.Model.Types.Complex;
+
+namespace RDCore.Tests.Model.Types;
+
+/// <summary>
+/// Regression coverage for a stack-overflow bug in <c>VBUserDefinedType</c>'s record equality and
+/// <c>ToString</c>: the compiler-generated implementations recurse forever between
+/// <see cref="RDCore.SDK.Model.Types.Abstract.VBType.DefaultValue"/> and
+/// <see cref="RDCore.SDK.Model.Values.Abstract.VBTypedValue.TypeInfo"/>, which reference each other
+/// (any <c>VBType</c>'s default value carries that same <c>VBType</c> back as its own <c>TypeInfo</c>).
+/// The fix overrides <c>PrintMembers</c> on both base types to stop printing the cyclic side, and fixes
+/// a related bug uncovered along the way: <see cref="VBUserDefinedType"/>'s identity comparison used
+/// <see cref="Uri"/>'s own <c>Equals</c>, which ignores <see cref="Uri.Fragment"/> — the very part of
+/// these symbol URIs that encodes which module/member the symbol actually is.
+/// </summary>
+[TestClass]
+public sealed class VBUserDefinedTypeTests
+{
+    private static VBUserDefinedType Udt(string name, string moduleUri = "file://rdcore-test")
+    {
+        var uri = new Uri($"{moduleUri}#{name}");
+        var symbol = new VBUserDefinedTypeMemberSymbol(uri, uri, name, ScopeKind.Module, SourceRange.Empty, SourceRange.Empty, AccessModifier.Public);
+        return new VBUserDefinedType(symbol, []);
+    }
+
+    [TestMethod]
+    public void DistinctUdtsSharingAWorkspaceRoot_AreNotEqual()
+    {
+        var foo = Udt("Foo");
+        var bar = Udt("Bar");
+
+        Assert.IsFalse(foo == bar);
+        Assert.IsFalse(foo.Equals(bar));
+        Assert.AreNotEqual(foo.GetHashCode(), bar.GetHashCode());
+    }
+
+    [TestMethod]
+    public void UdtsAtTheSameSymbolLocation_AreEqual()
+    {
+        var first = Udt("Foo");
+        var second = Udt("Foo");
+
+        Assert.IsTrue(first == second);
+        Assert.IsTrue(first.Equals(second));
+        Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [TestMethod]
+    public void ToString_DoesNotStackOverflow()
+    {
+        var udt = Udt("Foo");
+
+        var text = udt.ToString();
+
+        Assert.IsNotNull(text);
+        StringAssert.Contains(text, "Foo");
+    }
+
+    [TestMethod]
+    public void Equals_DoesNotStackOverflow_WhenComparingTwoDistinctInstances()
+    {
+        var foo = Udt("Foo");
+        var bar = Udt("Bar");
+
+        // the assertion itself is secondary here: merely reaching it without an
+        // InsufficientExecutionStackException is the regression this guards against.
+        _ = foo.Equals(bar);
+    }
+
+    [TestMethod]
+    public void ToString_OnAnyVBType_DoesNotStackOverflow()
+        // VBUserDefinedType is not special-cased: the cycle is between VBType.DefaultValue and
+        // VBTypedValue.TypeInfo, shared by every VBType/VBTypedValue pair in the platform.
+        => Assert.IsNotNull(VBLongType.TypeInfo.ToString());
+}

--- a/RDCore.Tests/Semantics/Runtime/VBUserDefinedTypeLetCoercionTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/VBUserDefinedTypeLetCoercionTests.cs
@@ -23,6 +23,8 @@ public sealed class VBUserDefinedTypeLetCoercionTests : LetCoercionRuntimeSemant
 
     // Symbol identity is location-based, not name-based — a distinct module name per UDT (via
     // TestModuleUri's own module-name parameter) gives each Udt(...) call a genuinely distinct type.
+    // (RDCore.Tests.Model.Types.VBUserDefinedTypeTests covers VBUserDefinedType equality/ToString
+    // directly, including the stack-overflow regression this used to hit.)
     private static VBUserDefinedType Udt(string name)
     {
         var uri = TestUri.TestModuleUri(name);
@@ -46,12 +48,11 @@ public sealed class VBUserDefinedTypeLetCoercionTests : LetCoercionRuntimeSemant
 
     [TestMethod]
     public void UdtSourceIntoNonMatchingTarget_IsTypeMismatch()
-        // a non-UDT, non-Variant target exercises the same "not the same UDT type" branch as a
-        // different UDT would, without needing a second VBUserDefinedType instance: comparing two
-        // distinct VBUserDefinedType/VBUserDefinedTypeMemberSymbol records for equality currently
-        // stack-overflows (InsufficientExecutionStackException) — a separate, pre-existing bug in the
-        // symbol/type model, out of scope for let-coercion; flagged as a follow-up.
         => AssertError(Coerce(Sut(), new VBUserDefinedTypeValue(Udt("Foo")), VBLongType.TypeInfo), VBRuntimeErrorId.TypeMismatch);
+
+    [TestMethod]
+    public void DifferentUdtSource_IsTypeMismatch()
+        => AssertError(Coerce(Sut(), new VBUserDefinedTypeValue(Udt("Foo")), Udt("Bar")), VBRuntimeErrorId.TypeMismatch);
 
     [TestMethod]
     public void NumericSource_IntoUdtTarget_IsTypeMismatch()


### PR DESCRIPTION
VBType.DefaultValue and VBTypedValue.TypeInfo reference each other, and the compiler-generated PrintMembers prints both in full, so ToString() on any VBType/VBTypedValue recursed forever. override PrintMembers on both to break the cycle.

also fixes a real bug this surfaced: VBUserDefinedType.Equals compared Symbol.Uri with Uri's own Equals, which ignores the fragment - the part of these symbol uris that actually encodes identity - so distinct UDTs sharing a workspace root silently compared equal (and let-coerced into each other as if they were the same type).