### PR TITLE
runtime: fix operand coercion errors

### DIFF
--- a/RDCore.Runtime/Semantics/Abstract/OperatorRuntimeSemantics.cs
+++ b/RDCore.Runtime/Semantics/Abstract/OperatorRuntimeSemantics.cs
@@ -208,11 +208,24 @@ where TFlags : struct, Enum
             frame = frame with { EffectiveType = effectiveType };
 
             // 2. Validate the operands (let-coercion and overflow checks).
-            var validOperands = Enumerable.Range(0, frame.Operands.Length)
+            var operandValidations = Enumerable.Range(0, frame.Operands.Length)
                 .Select(index => ValidateOperand(resolver, expression, frame, (InputIndex)index))
-                .Where(validation => validation.Result is not null)
-                .Select(validation => validation.Result)
-                .Cast<VBTypedValue>();
+                .ToArray();
+
+            // a genuine coercion failure (e.g. Overflow) on any operand must short-circuit evaluation
+            // here with its own error - silently dropping the operand would leave EvaluateExpressionResult
+            // indexing into an array shorter than frame.Operands, and hide the real error entirely.
+            foreach (var validation in operandValidations)
+            {
+                if (validation.Result is null)
+                {
+                    return RuntimeSemanticsEvaluationResult.Error(validation.ErrorInfo
+                        ?? OnRuntimeError(VBRuntimeErrorId.InternalError, expression,
+                            Exceptions.VBRuntimeInternalError_EvaluateOperatorRuntimeSemanticsNullApplicableResult_Verbose));
+                }
+            }
+
+            var validOperands = operandValidations.Select(validation => validation.Result!);
 
             // 3. Evaluate the result.
             var evaluateResult = EvaluateExpressionResult(resolver, context, expression, frame with { Operands = [.. validOperands] });

--- a/RDCore.Tests/Semantics/Runtime/BinaryLogicalOperatorRuntimeTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/BinaryLogicalOperatorRuntimeTests.cs
@@ -1,4 +1,5 @@
 using RDCore.Runtime.Semantics.Operators.Logical;
+using RDCore.SDK.Model.Errors;
 using RDCore.SDK.Model.Values.Intrinsic;
 using RDCore.SDK.Runtime.Shared;
 
@@ -22,6 +23,18 @@ public sealed class BinaryLogicalOperatorRuntimeTests : OperatorLogicalRuntimeSe
     [TestCategory("MS-VBAL 5.6.9.8.2 Binary 'And' Operator")]
     public void And_Long()
         => AssertResult<VBLongValue>(Evaluate(And(), new VBLongValue(12), new VBLongValue(10)), 8);
+
+    [TestMethod]
+    [TestCategory("RD-VBAL §5.0.2.1 Operator Evaluation")]
+    public void And_OperandLetCoercionOverflows_SurfacesTheOverflowError()
+    {
+        // Double,Double resolves an effective type of Long (MS-VBAL 5.6.9.8); the base pipeline's
+        // operand-validation step must then let-coerce each Double operand to Long, and double.MaxValue
+        // genuinely overflows Long. This must surface as the coercion's own Overflow error rather than
+        // silently dropping the operand and crashing EvaluateExpressionResult with an out-of-range index.
+        var op = new BinaryAndLogicalOperatorRuntimeSemantics(RealCoercionProvider(), Formatter());
+        AssertError(Evaluate(op, new VBDoubleValue(double.MaxValue), new VBDoubleValue(1)), VBRuntimeErrorId.Overflow);
+    }
 
     [TestMethod]
     [TestCategory("MS-VBAL 5.6.9.8.2 Binary 'And' Operator")]

--- a/RDCore.Tests/Semantics/Runtime/OperatorArithmeticRuntimeSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/OperatorArithmeticRuntimeSemanticsTests.cs
@@ -13,6 +13,8 @@ using RDCore.SDK.Runtime.Abstract;
 using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Runtime.Shared;
 using RDCore.SDK.Semantics;
+using RDCore.SDK.Semantics.Analysis;
+using RDCore.SDK.Semantics.Builders;
 using RDCore.SDK.Semantics.Context;
 using RDCore.SDK.Services.VerboseMessages;
 
@@ -45,6 +47,37 @@ public abstract class OperatorArithmeticRuntimeSemanticsTests
                 return LetCoercionResult.Success(source is VBDateValue date ? new VBDoubleValue(date.SerialValue) : source);
             });
         return provider;
+    }
+
+    /// <summary>
+    /// The real Numeric, String, Date and Boolean let-coercion strategies — for tests that need an
+    /// operand's own let-coercion to genuinely run (and potentially fail), rather than the identity
+    /// passthrough of <see cref="FakeProvider"/>.
+    /// </summary>
+    protected static ILetCoercionRuntimeSemanticsProvider RealCoercionProvider()
+    {
+        var fmt = Substitute.For<IVerboseMessageBuilder>();
+        var handle = new ProviderHandle();
+        ILetCoercionRuntimeSemantics[] strategies =
+        [
+            new VBNumericLetCoercionTypeRuntimeSemantics(fmt, handle),
+            new VBStringLetCoercionRuntimeSemantics(fmt, handle),
+            new VBDateLetCoercionRuntimeSemantics(handle, fmt),
+            new VBBooleanLetCoercionRuntimeSemantics(handle, fmt),
+        ];
+        var provider = new LetCoercionRuntimeSemanticsProvider(strategies, fmt);
+        handle.Inner = provider;
+        return provider;
+    }
+
+    /// <summary>Breaks the provider ⇄ strategy construction cycle (strategies take the provider itself for recursive coercions).</summary>
+    private sealed class ProviderHandle : ILetCoercionRuntimeSemanticsProvider
+    {
+        public ILetCoercionRuntimeSemanticsProvider Inner { get; set; } = default!;
+        public LetCoercionResult EvaluateLetCoercionSemantics(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame)
+            => Inner.EvaluateLetCoercionSemantics(resolver, expression, frame);
+        public LetCoercionAnalysisContext Analyze(ISymbolResolver resolver, ILetCoercionSemanticContextBuilder builder, VBOperatorExpression expression, LetCoercionStackFrame frame)
+            => Inner.Analyze(resolver, builder, expression, frame);
     }
 
     private static readonly VBBinaryOperatorExpressionNode ThrowawayBinary = new(

--- a/RDCore.Tests/Semantics/Runtime/OperatorLetCoerceRuntimeSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/OperatorLetCoerceRuntimeSemanticsTests.cs
@@ -1,6 +1,4 @@
-using NSubstitute;
 using RDCore.Runtime.Execution.Frames;
-using RDCore.Runtime.Semantics.LetCoercion;
 using RDCore.Runtime.Semantics.Operators;
 using RDCore.SDK.Model.AST.Expressions;
 using RDCore.SDK.Model.Types;
@@ -8,13 +6,8 @@ using RDCore.SDK.Model.Types.Abstract;
 using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Intrinsic;
 using RDCore.SDK.Model.Values.Meta;
-using RDCore.SDK.Runtime.Abstract;
-using RDCore.SDK.Runtime.Abstract.Execution;
 using RDCore.SDK.Runtime.Shared;
-using RDCore.SDK.Semantics.Analysis;
-using RDCore.SDK.Semantics.Builders;
 using RDCore.SDK.Semantics.Context;
-using RDCore.SDK.Services.VerboseMessages;
 
 namespace RDCore.Tests.Semantics.Runtime;
 
@@ -45,36 +38,5 @@ public abstract class OperatorLetCoerceRuntimeSemanticsTests : OperatorArithmeti
         var frame = new OperatorEvaluationFrame(
             NodeId, [VBLongType.TypeInfo.DefaultValue, new VBTypeDescValue(targetType)], VBUnknownType.TypeInfo);
         return op.DetermineOperatorEffectiveType(null!, new ConversionOperationSemanticContext(), ThrowawayBinary, frame);
-    }
-
-    /// <summary>
-    /// The real Numeric, String, Date and Boolean let-coercion strategies — the operator's own job is
-    /// delegation, but delegating to a fake identity passthrough would never exercise an actual
-    /// coercion.
-    /// </summary>
-    protected static ILetCoercionRuntimeSemanticsProvider RealCoercionProvider()
-    {
-        var fmt = Substitute.For<IVerboseMessageBuilder>();
-        var handle = new ProviderHandle();
-        ILetCoercionRuntimeSemantics[] strategies =
-        [
-            new VBNumericLetCoercionTypeRuntimeSemantics(fmt, handle),
-            new VBStringLetCoercionRuntimeSemantics(fmt, handle),
-            new VBDateLetCoercionRuntimeSemantics(handle, fmt),
-            new VBBooleanLetCoercionRuntimeSemantics(handle, fmt),
-        ];
-        var provider = new LetCoercionRuntimeSemanticsProvider(strategies, fmt);
-        handle.Inner = provider;
-        return provider;
-    }
-
-    /// <summary>Breaks the provider ⇄ strategy construction cycle (strategies take the provider itself for recursive coercions).</summary>
-    private sealed class ProviderHandle : ILetCoercionRuntimeSemanticsProvider
-    {
-        public ILetCoercionRuntimeSemanticsProvider Inner { get; set; } = default!;
-        public LetCoercionResult EvaluateLetCoercionSemantics(ISymbolResolver resolver, VBOperatorExpression expression, LetCoercionStackFrame frame)
-            => Inner.EvaluateLetCoercionSemantics(resolver, expression, frame);
-        public LetCoercionAnalysisContext Analyze(ISymbolResolver resolver, ILetCoercionSemanticContextBuilder builder, VBOperatorExpression expression, LetCoercionStackFrame frame)
-            => Inner.Analyze(resolver, builder, expression, frame);
     }
 }

--- a/RDCore.Tests/Semantics/Runtime/OperatorLogicalRuntimeSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Runtime/OperatorLogicalRuntimeSemanticsTests.cs
@@ -21,8 +21,10 @@ namespace RDCore.Tests.Semantics.Runtime;
 /// </summary>
 public abstract class OperatorLogicalRuntimeSemanticsTests : OperatorArithmeticRuntimeSemanticsTests
 {
+    // Identity must be a real SyntaxNodeId (see OperatorLetCoerceRuntimeSemanticsTests for why): the
+    // real coercion provider's recursion guard hashes LetCoercionStackFrame, which hashes this Identity.
     private static readonly VBBinaryOperatorExpressionNode ThrowawayBinary = new(
-        "And", default, TestLocations.TestLocation,
+        "And", NodeId, TestLocations.TestLocation,
         [
             new LiteralExpressionNode(default, TestLocations.TestLocationLHS, new VBLongValue(0)),
             new LiteralExpressionNode(default, TestLocations.TestLocationRHS, new VBLongValue(0)),


### PR DESCRIPTION
Evaluate() filtered out any operand whose let-coercion failed instead of short-circuiting with the coercion's own error, so the real error (e.g. Overflow) never reached the caller and EvaluateExpressionResult indexed into a shrunk operand array instead, throwing IndexOutOfRangeException. Affects every operator family, not just one.