### PR TITLE
tests: un-ignore DifferentUdt_IsInvalid now that #197 fixed it

### DIFF
--- a/RDCore.Tests/Semantics/Static/LetCoercionStaticSemanticsTests.cs
+++ b/RDCore.Tests/Semantics/Static/LetCoercionStaticSemanticsTests.cs
@@ -187,7 +187,6 @@ public sealed class LetCoercionStaticSemanticsTests : StaticSemanticsTests
     }
 
     [TestMethod]
-    [Ignore("Blocked on a pre-existing VBUserDefinedType/VBUserDefinedTypeMemberSymbol record-equality bug (location-based symbol identity treats two distinctly-named UDTs as equal) — tracked separately, being fixed on branch fix/udt-equality-stack-overflow.")]
     public void DifferentUdt_IsInvalid()
         => AssertInvalid(Udt("Foo"), Udt("Bar"));
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -102,7 +102,7 @@ RDCore est en phase active de développement **pré-alpha**. La **spécification
 
 **RDCore.Diagnostics** — extension d'inspection _core_ · 🚧 squelette d'analyseur; découverte depuis son _manifest_ généré et démarrée par le serveur de langage lors de l'assemblage de la plateforme.
 
-**Tests** · 🎯 cible ~70% de couverture de lignes (le badge ci-haut est à jour) — sémantiques d'opérateurs et cycle de vie de la plateforme bien couverts; grammaire du _parser_ et CLI minces; le _runtime_ au-delà des opérateurs n'a encore rien à couvrir.
+**Tests** · 🎯 cible ~70% de couverture de lignes (le badge ci-haut est à jour) — sémantiques d'opérateurs et de _let-coercions_ (_runtime_ + statiques) bien couvertes; grammaire du _parser_ et CLI minces; les _statements_ / l'interpréteur du _runtime_ n'ont encore rien à couvrir.
 
 **Contributions** — individuelles ✅ ouvertes ([CLA](CLA.fr.md)) · corporatives ⏳ à venir
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ RDCore is in active **pre-alpha** development. The **specification** and **docum
 
 **RDCore.Diagnostics** — core inspection extension · 🚧 analyzer skeleton; discovered from its generated manifest and brought up by the language server during platform assembly.
 
-**Tests** · 🎯 target ~70% line coverage (badge above is live) — operator semantics and platform lifecycle well covered; parser grammar and CLI thin; runtime beyond operators has nothing to cover yet.
+**Tests** · 🎯 target ~70% line coverage (badge above is live) — operator and let-coercion semantics (runtime + static) well covered; parser grammar and CLI thin; runtime statement/interpreter work still has nothing to cover.
 
 **Contributions** — individuals ✅ open ([CLA](CLA.md)) · corporate ⏳ planned
 


### PR DESCRIPTION
The UDT/Symbol equality stack-overflow fix (#197) also fixed the underlying wrong-equality bug this test was blocked on; confirmed green. Also refreshes both READMEs' Tests row, stale since let- coercion (runtime and static) went from near-zero to well-covered across #196-#198.