### PR TITLE
languageserver: don't project procedure locals as symbol members

### DIFF
--- a/RDCore.LanguageServer/Symbols/SymbolDescriptorProjector.cs
+++ b/RDCore.LanguageServer/Symbols/SymbolDescriptorProjector.cs
@@ -52,10 +52,16 @@ internal static class SymbolDescriptorProjector
             SelectionRange = accessible?.SelectionRange ?? default,
             Definitions = DefinitionsOf(symbol),
             Parameters = ParametersOf(symbol),
-            Members = [.. children.Select(child => Describe(child, KindOf(child), []))],
+            Members = [.. children.Where(IsNestableMember).Select(child => Describe(child, KindOf(child), []))],
             External = ExternalOf(symbol),
         };
     }
+
+    // only Enum constants and UDT fields are meant to nest under their owner (see this class's own
+    // remarks); a procedure's locals (VBLocalVariableSymbol/VBLocalConstantSymbol) share the same
+    // childrenByParent lookup by virtue of their ParentUri, but were never meant to project into the
+    // descriptor tree — KindOf has no arm for them, and none is wanted here.
+    private static bool IsNestableMember(Symbol symbol) => symbol is VBEnumConstMemberSymbol or VBUserDefinedTypeFieldSymbol;
 
     // carried only for a multi-branch symbol; the common single-declaration descriptor stays lean and
     // consumers read Range/SelectionRange.

--- a/RDCore.Tests/LanguageServer/SymbolDescriptorProjectorTests.cs
+++ b/RDCore.Tests/LanguageServer/SymbolDescriptorProjectorTests.cs
@@ -144,6 +144,35 @@ public sealed class SymbolDescriptorProjectorTests
             [new VBClassModuleSymbol(WorkspaceRoot, ModuleUri, "Whatever")], ModuleUri));
 
     [TestMethod]
+    public void ProcedureWithALocalVariable_DoesNotThrow_AndTheLocalIsNotProjectedAsAMember()
+        // regression: KindOf's throwing default (post-#204) had no arm for VBLocalVariableSymbol, so
+        // any procedure declaring a local Dim aborted projection for the whole module.
+    {
+        var descriptor = Project("""
+            Public Sub DoWork()
+                Dim total As Long
+            End Sub
+            """).Single();
+
+        Assert.AreEqual(SymbolDescriptorKind.Procedure, descriptor.Kind);
+        Assert.AreEqual(0, descriptor.Members.Length);
+    }
+
+    [TestMethod]
+    public void ProcedureWithALocalConstant_DoesNotThrow_AndTheLocalIsNotProjectedAsAMember()
+        // same regression, VBLocalConstantSymbol has no KindOf arm either.
+    {
+        var descriptor = Project("""
+            Public Sub DoWork()
+                Const Max As Long = 10
+            End Sub
+            """).Single();
+
+        Assert.AreEqual(SymbolDescriptorKind.Procedure, descriptor.Kind);
+        Assert.AreEqual(0, descriptor.Members.Length);
+    }
+
+    [TestMethod]
     public void ConditionalCompilation_ProjectsOneDescriptorCarryingEveryBranch()
     {
         var descriptors = Project("""


### PR DESCRIPTION
KindOf's throwing default (#204) had no arm for VBLocalVariableSymbol or VBLocalConstantSymbol. Procedure locals share the same childrenByParent lookup as Enum constants and UDT fields (by virtue of their ParentUri), so any procedure declaring a local Dim/Const/ReDim/Static threw NotSupportedException during Describe, aborting symbol projection for the whole module.

Only Enum constants and UDT fields were ever meant to nest under their owner (per this class's own remarks) - filters children to just those kinds instead of adding KindOf arms that would start surfacing locals in the LSP symbol tree.

Found by an external adversarial review of #204.