### PR TITLE
runtime: fix reference-cycle StackOverflow and TryAllocate leak

### DIFF
--- a/RDCore.Runtime/Execution/RuntimeSymbolResolver.cs
+++ b/RDCore.Runtime/Execution/RuntimeSymbolResolver.cs
@@ -38,7 +38,8 @@ public sealed class RuntimeSymbolResolver(ISymbolResolver names, ISessionStorage
     /// <summary>
     /// Reserves storage sized for <paramref name="value"/> and binds it to <paramref name="symbol"/>,
     /// reachable afterwards through both <see cref="GetValue"/> (by symbol) and <see cref="TryRead"/>
-    /// (by <paramref name="address"/>).
+    /// (by <paramref name="address"/>). A symbol already allocated has its previous storage freed
+    /// first, so re-allocating never leaks the old block or leaves it readable with a stale handle.
     /// </summary>
     /// <returns>
     /// <c>false</c> if the session's memory space is exhausted; the caller is responsible for reporting
@@ -47,8 +48,14 @@ public sealed class RuntimeSymbolResolver(ISymbolResolver names, ISessionStorage
     /// </returns>
     public bool TryAllocate(Symbol symbol, VBTypedValue value, out MemoryAddress address)
     {
+        if (_addressBySymbol.TryGetValue(symbol.SemanticId, out var previous))
+        {
+            storage.TryDeallocate(previous);
+        }
+
         if (!storage.TryAllocate(value.Size, value.Handle, out address))
         {
+            _addressBySymbol.Remove(symbol.SemanticId);
             return false;
         }
 

--- a/RDCore.SDK/Model/Values/Bindings/ReferenceBindingHandle.cs
+++ b/RDCore.SDK/Model/Values/Bindings/ReferenceBindingHandle.cs
@@ -1,6 +1,7 @@
 ﻿using RDCore.SDK.Model.Values.Abstract;
 using RDCore.SDK.Model.Values.Runtime;
 using RDCore.SDK.Runtime.Abstract.Execution;
+using RDCore.SDK.Runtime.Shared;
 
 namespace RDCore.SDK.Model.Values.Bindings;
 
@@ -21,8 +22,25 @@ public record class ReferenceBindingHandle : IBindingHandle
 
     // follows the reference through the resolver's runtime memory map; a reference that doesn't (yet)
     // resolve to anything bound falls back to yielding itself, e.g. Nothing or a dangling address.
-    public IRuntimeValue GetValue(ISymbolResolver resolver)
-        => resolver.TryRead(_value.Value, out var bound) ? bound.GetValue(resolver) : _value;
+    public IRuntimeValue GetValue(ISymbolResolver resolver) => GetValue(resolver, [_value.Value]);
+
+    // a chain of references can cycle (Set a = b : Set b = a) or self-reference (Set x = x); each hop
+    // through another ReferenceBindingHandle is tracked by the address it targets next, so a repeat
+    // stops the walk instead of recursing until the stack overflows.
+    private IRuntimeValue GetValue(ISymbolResolver resolver, HashSet<MemoryAddress> visited)
+    {
+        if (!resolver.TryRead(_value.Value, out var bound))
+        {
+            return _value;
+        }
+
+        if (bound is not ReferenceBindingHandle next)
+        {
+            return bound.GetValue(resolver);
+        }
+
+        return visited.Add(next._value.Value) ? next.GetValue(resolver, visited) : _value;
+    }
 
     public void SetValue(ISymbolResolver resolver, IRuntimeValue value) => _value = value is VBRuntimeReference reference
         ? reference : throw new ArgumentException($"Expected {nameof(VBRuntimeReference)} value", nameof(value));

--- a/RDCore.Tests/Model/Values/Bindings/BindingHandleTests.cs
+++ b/RDCore.Tests/Model/Values/Bindings/BindingHandleTests.cs
@@ -99,6 +99,59 @@ public sealed class BindingHandleTests
             new ReferenceBindingHandle(new VBRuntimeReference(new MemoryAddress(42))).GetValue(Resolver));
 
     [TestMethod]
+    public void ReferenceBindingHandle_GetValue_SelfReference_StopsInsteadOfOverflowing()
+        // VBA "Set x = x": x's own storage holds a reference to its own address.
+    {
+        var address = new MemoryAddress(1);
+        var sut = new ReferenceBindingHandle(new VBRuntimeReference(address));
+        var resolver = Substitute.For<ISymbolResolver>();
+        resolver.TryRead(address, out Arg.Any<IBindingHandle?>()).Returns(call =>
+        {
+            call[1] = sut;
+            return true;
+        });
+
+        var result = sut.GetValue(resolver);
+
+        Assert.AreEqual(new VBRuntimeReference(address), result);
+    }
+
+    [TestMethod]
+    public void ReferenceBindingHandle_GetValue_TwoCycle_StopsInsteadOfOverflowing()
+        // VBA "Set a = b : Set b = a": each variable's storage references the other's address.
+    {
+        var addressA = new MemoryAddress(1);
+        var addressB = new MemoryAddress(2);
+        var a = new ReferenceBindingHandle(new VBRuntimeReference(addressB));
+        var b = new ReferenceBindingHandle(new VBRuntimeReference(addressA));
+        var resolver = Substitute.For<ISymbolResolver>();
+        resolver.TryRead(addressA, out Arg.Any<IBindingHandle?>()).Returns(call => { call[1] = a; return true; });
+        resolver.TryRead(addressB, out Arg.Any<IBindingHandle?>()).Returns(call => { call[1] = b; return true; });
+
+        var result = a.GetValue(resolver);
+
+        Assert.AreEqual(new VBRuntimeReference(addressA), result);
+    }
+
+    [TestMethod]
+    public void ReferenceBindingHandle_GetValue_NonCyclicChain_StillFollowsThroughToTheFinalValue()
+        // a reference to a reference to a real value is not a cycle and must still resolve correctly.
+    {
+        var addressA = new MemoryAddress(1);
+        var addressB = new MemoryAddress(2);
+        var final = Substitute.For<IBindingHandle>();
+        final.GetValue(Arg.Any<ISymbolResolver>()).Returns(new VBRuntimeValue<int>(9));
+        var a = new ReferenceBindingHandle(new VBRuntimeReference(addressB));
+        var resolver = Substitute.For<ISymbolResolver>();
+        resolver.TryRead(addressA, out Arg.Any<IBindingHandle?>()).Returns(call => { call[1] = a; return true; });
+        resolver.TryRead(addressB, out Arg.Any<IBindingHandle?>()).Returns(call => { call[1] = final; return true; });
+
+        var result = new ReferenceBindingHandle(new VBRuntimeReference(addressA)).GetValue(resolver);
+
+        Assert.AreEqual(9, ((VBRuntimeValue<int>)result).StoredValue);
+    }
+
+    [TestMethod]
     public void ReferenceBindingHandle_SetValue_AcceptsAVBRuntimeReference()
     {
         var sut = new ReferenceBindingHandle(new VBRuntimeReference(new MemoryAddress(1)));

--- a/RDCore.Tests/Runtime/Execution/RuntimeSymbolResolverTests.cs
+++ b/RDCore.Tests/Runtime/Execution/RuntimeSymbolResolverTests.cs
@@ -120,4 +120,44 @@ public sealed class RuntimeSymbolResolverTests
     [TestMethod]
     public void TryDeallocate_UnallocatedSymbol_ReturnsFalse()
         => Assert.IsFalse(Sut(out _, out _).TryDeallocate(Symbol("Foo")));
+
+    [TestMethod]
+    public void TryAllocate_SameSymbolTwice_FreesThePreviousBlock_NoLeakNoStaleRead()
+    {
+        var sut = Sut(out _, out var storage);
+        var symbol = Symbol("Foo");
+        var first = new VBLongValue(1);
+        var second = new VBLongValue(2);
+        Assert.IsTrue(sut.TryAllocate(symbol, first, out var firstAddress));
+
+        Assert.IsTrue(sut.TryAllocate(symbol, second, out var secondAddress));
+
+        Assert.AreSame(second.Handle, sut.GetValue(symbol));
+        // the first block was genuinely freed (not leaked): a same-size re-allocation reuses it
+        // immediately, per SessionMemory's free-list fast path (SessionMemoryTests.TryAllocate_ReusesFreeMemory).
+        Assert.AreEqual(firstAddress, secondAddress);
+        // and reading it returns the CURRENT handle, not a stale leftover from the first allocation.
+        Assert.IsTrue(storage.TryRead(secondAddress, out var bound));
+        Assert.AreSame(second.Handle, bound);
+    }
+
+    [TestMethod]
+    public void TryAllocate_SameSymbolTwice_OutOfMemoryOnSecondAllocation_RemovesTheMapping()
+    {
+        var names = Substitute.For<ISymbolResolver>();
+        var allocator = Substitute.For<ISessionMemoryAllocator>();
+        allocator.TryAllocate(Arg.Any<int>(), out Arg.Any<MemoryAddress>()).Returns(
+            call => { call[1] = new MemoryAddress(1); return true; },
+            call => { call[1] = default(MemoryAddress); return false; });
+        allocator.TryDeallocate(Arg.Any<MemoryAddress>(), out Arg.Any<SessionMemoryBlock>()).Returns(true);
+        var storage = new SessionStorage(allocator);
+        var sut = new RuntimeSymbolResolver(names, storage);
+        var symbol = Symbol("Foo");
+        Assert.IsTrue(sut.TryAllocate(symbol, new VBLongValue(1), out _));
+
+        Assert.IsFalse(sut.TryAllocate(symbol, new VBLongValue(2), out _));
+
+        // freed on the way to the failed re-allocation, and not left pointing at a freed block.
+        Assert.ThrowsExactly<KeyNotFoundException>(() => sut.GetValue(symbol));
+    }
 }


### PR DESCRIPTION
ReferenceBindingHandle.GetValue recursed through a resolved reference with no cycle guard - a self-reference (Set x = x) or a two-variable cycle (Set a = b : Set b = a) recursed forever and crashed the process. Now tracks visited addresses through the chain and stops on a repeat.

RuntimeSymbolResolver.TryAllocate overwrote a symbol's address mapping on a second allocation without freeing the first block, leaking memory and leaving the old address readable with a stale handle. Now frees the symbol's previous block first; if the new allocation then fails, the mapping is removed rather than left pointing at freed memory.

Found by an external adversarial review of #205.