### PR TITLE
parsing: fix syntax-error diagnostics landing one line low

### DIFF
--- a/RDCore.Parsing/ModuleParser.cs
+++ b/RDCore.Parsing/ModuleParser.cs
@@ -225,7 +225,9 @@ internal class ErrorListener(Uri uri) : IAntlrErrorListener<IToken>
 
     public void SyntaxError([NotNull] IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e)
     {
-        var location = new SourceLocation(_uri, new(line, charPositionInLine, line, charPositionInLine));
+        // ANTLR's line is 1-based; SourcePosition is documented zero-based (charPositionInLine already
+        // is), matching the same -1 conversion VBABaseParserRuleContext applies to node locations.
+        var location = new SourceLocation(_uri, new(line - 1, charPositionInLine, line - 1, charPositionInLine));
         _errors.Add(VBSyntaxErrorInfo.For(VBCompileErrorId.SyntaxError, location, msg));
     }
 

--- a/RDCore.Tests/Parser/ParserResilienceTests.cs
+++ b/RDCore.Tests/Parser/ParserResilienceTests.cs
@@ -72,6 +72,19 @@ public sealed class ParserResilienceTests
     }
 
     [TestMethod]
+    public void SyntaxError_LocatesToTheZeroBasedPhysicalLine()
+        // regression: ErrorListener.SyntaxError passed ANTLR's 1-based line straight through, landing
+        // every diagnostic one line below the token that actually caused it.
+    {
+        var result = Parse("Option Explicit\r\nPublic Sub Foo(\r\n");
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotEmpty(result.SyntaxErrors);
+        // "Public Sub Foo(" is physical line 2 (1-based) -> zero-based line 1.
+        Assert.AreEqual(1, result.SyntaxErrors[0].Location.Range.Start.Line);
+    }
+
+    [TestMethod]
     // valid VBA the declaration pass used to reject — casing, culture, empty forms.
     [DataRow("public Sub Foo()\r\nEnd Sub", DisplayName = "lowercase visibility keyword")]
     [DataRow("PRIVATE Function F() As Long\r\nEnd Function", DisplayName = "uppercase visibility keyword")]


### PR DESCRIPTION
ErrorListener.SyntaxError stored ANTLR's 1-based line straight into a SourcePosition, which is documented and consumed as zero-based - inconsistent with VBABaseParserRuleContext, which already applies the same -1 conversion for node locations. Every grammar syntax error landed one line below its actual token.

Found by an external adversarial review.