### PR TITLE
model: map SyntaxError to its "Syntax error" message

### DIFF
--- a/RDCore.SDK/Model/Errors/VBCompileErrorInfo.cs
+++ b/RDCore.SDK/Model/Errors/VBCompileErrorInfo.cs
@@ -56,6 +56,8 @@ public record class VBCompileErrorInfo : VBErrorInfo
         // 💥 "this should never happen" - but in case it does... the dictionary key exists:
         [VBCompileErrorId.UnspecifiedCompileError] = Exceptions.VBCompileError_UnspecifiedError,
 
+        [VBCompileErrorId.SyntaxError] = Exceptions.VBSyntaxError_DefaultMessage,
+
         [VBCompileErrorId.NumericLiteralOverflow] = Exceptions.VBCompileError_NumericLiteralOverflow,
 
         [VBCompileErrorId.TypeMismatch] = Exceptions.VBCompileError_TypeMismatch,

--- a/RDCore.Tests/Model/DiagnosticFactoryTests.cs
+++ b/RDCore.Tests/Model/DiagnosticFactoryTests.cs
@@ -35,5 +35,8 @@ public sealed class DiagnosticFactoryTests
         Assert.AreEqual("RDCore", diagnostic.Source);
         Assert.AreEqual(Where.Range.ToLsp(), diagnostic.Range);
         Assert.IsNotNull(diagnostic.Data, "the error id and verbose detail ride Data");
+        // regression: VBCompileErrors had no entry for SyntaxError, so every grammar error (the
+        // overwhelmingly common syntax-error path) fell back to "Unspecified error".
+        Assert.AreEqual("Syntax error", diagnostic.Message);
     }
 }


### PR DESCRIPTION
VBCompileErrors had no entry for VBCompileErrorId.SyntaxError, so GetErrorString fell back to "Unspecified error" - shown for every ANTLR grammar error, the overwhelmingly common syntax-error path, contradicting VBSyntaxErrorInfo's own doc ("Syntax error" unless specified otherwise). The VBSyntaxError_DefaultMessage resource (both languages) already existed and was just never wired into the dictionary.

Found by an external adversarial review.