### PR TITLE
runtime: add a byte-backed allocation kind to ISessionStorage

### DIFF
--- a/RDCore.Runtime/Execution/Memory/SessionStorage.cs
+++ b/RDCore.Runtime/Execution/Memory/SessionStorage.cs
@@ -13,6 +13,7 @@ namespace RDCore.Runtime.Execution.Memory;
 internal sealed class SessionStorage(ISessionMemoryAllocator allocator) : ISessionStorage
 {
     private readonly Dictionary<MemoryAddress, IBindingHandle> _handleByAddress = [];
+    private readonly Dictionary<MemoryAddress, byte[]> _bytesByAddress = [];
 
     public bool TryAllocate(int size, IBindingHandle handle, out MemoryAddress address)
     {
@@ -29,7 +30,7 @@ internal sealed class SessionStorage(ISessionMemoryAllocator allocator) : ISessi
         => _handleByAddress.TryGetValue(address, out handle);
 
     public bool TryDeallocate(MemoryAddress address)
-        => _handleByAddress.Remove(address) && allocator.TryDeallocate(address, out _);
+        => (_handleByAddress.Remove(address) || _bytesByAddress.Remove(address)) && allocator.TryDeallocate(address, out _);
 
     public bool TryRebind(MemoryAddress address, IBindingHandle handle)
     {
@@ -39,6 +40,40 @@ internal sealed class SessionStorage(ISessionMemoryAllocator allocator) : ISessi
         }
 
         _handleByAddress[address] = handle;
+        return true;
+    }
+
+    public bool TryAllocateBytes(int size, out MemoryAddress address)
+    {
+        if (!allocator.TryAllocate(size, out address))
+        {
+            return false;
+        }
+
+        _bytesByAddress[address] = new byte[size];
+        return true;
+    }
+
+    public bool TryReadBytes(MemoryAddress address, [NotNullWhen(true)][MaybeNullWhen(false)] out byte[]? bytes)
+    {
+        if (!_bytesByAddress.TryGetValue(address, out var stored))
+        {
+            bytes = null;
+            return false;
+        }
+
+        bytes = (byte[])stored.Clone();
+        return true;
+    }
+
+    public bool TryWriteBytes(MemoryAddress address, ReadOnlySpan<byte> bytes)
+    {
+        if (!_bytesByAddress.ContainsKey(address))
+        {
+            return false;
+        }
+
+        _bytesByAddress[address] = bytes.ToArray();
         return true;
     }
 }

--- a/RDCore.SDK/Runtime/Abstract/Execution/ISessionStorage.cs
+++ b/RDCore.SDK/Runtime/Abstract/Execution/ISessionStorage.cs
@@ -5,7 +5,11 @@ using System.Diagnostics.CodeAnalysis;
 namespace RDCore.SDK.Runtime.Abstract.Execution;
 
 /// <summary>
-/// Holds the actual <see cref="IBindingHandle"/> bound at each address in a session's memory space.
+/// Holds the actual value bound at each address in a session's memory space, as either a typed
+/// <see cref="IBindingHandle"/> or, for the handful of MS-VBAL constructs that operate on raw storage
+/// (<c>LSet</c> between two UDT variables; MS-VBAL only ever allows this and the already-value-level
+/// fixed-length <c>String</c> form), a plain byte buffer. An address is one kind or the other, never
+/// both.
 /// </summary>
 /// <remarks>
 /// <see cref="ISessionMemoryAllocator"/> deliberately does not cover this: it only accounts for
@@ -42,4 +46,24 @@ public interface ISessionStorage
     /// </summary>
     /// <returns><c>true</c> if <paramref name="address"/> was already allocated and its binding was replaced.</returns>
     bool TryRebind(MemoryAddress address, IBindingHandle handle);
+
+    /// <summary>
+    /// Reserves <paramref name="size"/> bytes through the underlying <see cref="ISessionMemoryAllocator"/>
+    /// as a raw byte buffer, zero-initialized, at the resulting address.
+    /// </summary>
+    /// <returns><c>false</c> if the underlying memory space is exhausted.</returns>
+    bool TryAllocateBytes(int size, out MemoryAddress address);
+
+    /// <summary>
+    /// Gets a copy of the byte buffer at <paramref name="address"/>.
+    /// </summary>
+    /// <returns><c>false</c> if <paramref name="address"/> is not a byte-backed allocation.</returns>
+    bool TryReadBytes(MemoryAddress address, [NotNullWhen(true)][MaybeNullWhen(false)] out byte[]? bytes);
+
+    /// <summary>
+    /// Replaces the byte buffer at <paramref name="address"/> with a copy of <paramref name="bytes"/>.
+    /// The new buffer's length need not match the original allocation's.
+    /// </summary>
+    /// <returns><c>false</c> if <paramref name="address"/> is not a byte-backed allocation.</returns>
+    bool TryWriteBytes(MemoryAddress address, ReadOnlySpan<byte> bytes);
 }

--- a/RDCore.Tests/Runtime/Memory/SessionStorageTests.cs
+++ b/RDCore.Tests/Runtime/Memory/SessionStorageTests.cs
@@ -85,4 +85,113 @@ public class SessionStorageTests
 
         Assert.IsFalse(sut.TryRebind(new MemoryAddress(42), Handle(1)));
     }
+
+    [TestMethod]
+    public void TryAllocateBytes_ReservesAZeroInitializedBuffer()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+
+        Assert.IsTrue(sut.TryAllocateBytes(4, out var address));
+
+        Assert.IsTrue(sut.TryReadBytes(address, out var bytes));
+        CollectionAssert.AreEqual(new byte[4], bytes);
+    }
+
+    [TestMethod]
+    public void TryAllocateBytes_OutOfMemory_ReturnsFalse()
+    {
+        var allocator = Substitute.For<ISessionMemoryAllocator>();
+        allocator.TryAllocate(Arg.Any<int>(), out Arg.Any<MemoryAddress>()).Returns(false);
+        var sut = new SessionStorage(allocator);
+
+        Assert.IsFalse(sut.TryAllocateBytes(4, out _));
+    }
+
+    [TestMethod]
+    public void TryWriteBytes_ThenTryReadBytes_RoundTrips()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+        Assert.IsTrue(sut.TryAllocateBytes(4, out var address));
+
+        Assert.IsTrue(sut.TryWriteBytes(address, [1, 2, 3, 4]));
+
+        Assert.IsTrue(sut.TryReadBytes(address, out var bytes));
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, bytes);
+    }
+
+    [TestMethod]
+    public void TryWriteBytes_ALengthDifferentFromTheOriginalAllocation_StillReplacesTheBuffer()
+        // the storage primitive doesn't enforce a size policy - LSet's truncate/pad-to-destination-size
+        // behavior belongs to the future consumer, not the raw byte buffer.
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+        Assert.IsTrue(sut.TryAllocateBytes(4, out var address));
+
+        Assert.IsTrue(sut.TryWriteBytes(address, [9, 9]));
+
+        Assert.IsTrue(sut.TryReadBytes(address, out var bytes));
+        CollectionAssert.AreEqual(new byte[] { 9, 9 }, bytes);
+    }
+
+    [TestMethod]
+    public void TryReadBytes_ReturnsACopy_MutatingItDoesNotAffectStorage()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+        sut.TryAllocateBytes(4, out var address);
+        sut.TryWriteBytes(address, [1, 2, 3, 4]);
+
+        sut.TryReadBytes(address, out var first);
+        first![0] = 99;
+
+        sut.TryReadBytes(address, out var second);
+        Assert.AreEqual(1, second![0]);
+    }
+
+    [TestMethod]
+    public void TryReadBytes_UnknownAddress_ReturnsFalse()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+
+        Assert.IsFalse(sut.TryReadBytes(new MemoryAddress(42), out _));
+    }
+
+    [TestMethod]
+    public void TryWriteBytes_UnknownAddress_ReturnsFalse()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+
+        Assert.IsFalse(sut.TryWriteBytes(new MemoryAddress(42), [1]));
+    }
+
+    [TestMethod]
+    public void TryReadBytes_OnAHandleBackedAddress_ReturnsFalse()
+        // the two allocation kinds are disjoint: an address is a handle slot or a byte buffer, never both.
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+        Assert.IsTrue(sut.TryAllocate(4, Handle(1), out var address));
+
+        Assert.IsFalse(sut.TryReadBytes(address, out _));
+    }
+
+    [TestMethod]
+    public void TryRead_OnAByteBackedAddress_ReturnsFalse()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+        Assert.IsTrue(sut.TryAllocateBytes(4, out var address));
+
+        Assert.IsFalse(sut.TryRead(address, out _));
+    }
+
+    [TestMethod]
+    public void TryDeallocate_RemovesAByteBackedAllocation_AndFreesTheUnderlyingMemory()
+    {
+        var sut = new SessionStorage(new SessionMemory(new(), PointerSize.x86));
+        Assert.IsTrue(sut.TryAllocateBytes(4, out var address));
+
+        Assert.IsTrue(sut.TryDeallocate(address));
+
+        Assert.IsFalse(sut.TryReadBytes(address, out _));
+        Assert.IsTrue(sut.TryAllocateBytes(4, out var reused));
+        Assert.AreEqual(address, reused);
+    }
 }


### PR DESCRIPTION
TryAllocateBytes/TryReadBytes/TryWriteBytes reserve and access a plain zero-initialized byte buffer, alongside the existing handle-backed TryAllocate/TryRead/TryRebind. An address is one kind or the other, never both - both TryDeallocate and each accessor already partition cleanly since the two kinds live in separate dictionaries.

This is the raw-storage primitive LSet between two UDT variables will need (MS-VBAL only allows LSet on String or UDT operands, and the String form is already handled at the value level by VBFixedStringValue - UDT is the only real consumer). No consumer wired yet, proven in isolation like RuntimeSymbolResolver and LetCoercionStackManager before it.